### PR TITLE
Make use of std::string_view as key of the map_type when we have C++1…

### DIFF
--- a/tao/x11/portable_server/operation_table_std_map.h
+++ b/tao/x11/portable_server/operation_table_std_map.h
@@ -72,7 +72,13 @@ public:
                     const TAO::Operation_Skeletons skel_ptr) override;
 
 private:
-  typedef std::unordered_map<std::string, TAO::Operation_Skeletons> map_type;
+#if defined (ACE_HAS_CPP17)
+  typedef std::string_view key_map_type;
+#else
+  typedef std::string key_map_type;
+#endif /* ACE_HAS_CPP17 */
+
+  typedef std::unordered_map<key_map_type, TAO::Operation_Skeletons> map_type;
 
   map_type map_ {};
 


### PR DESCRIPTION
…7 or newer, this is more optimal in terms of footprint and performance, issue #4826

    * tao/x11/portable_server/operation_table_std_map.h: