### PR TITLE
Generate explicit virtual destructors.

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_post.erb
@@ -11,7 +11,7 @@ protected:
 
   explicit <%= amic_cxxname %> (<%= proxy_cxxname %>_ptr p, bool inherited = false);
   <%= amic_cxxname %> () = default;
-  ~<%= amic_cxxname %> () = default;
+  virtual ~<%= amic_cxxname %> () = default;
 
 private:
   /** @name Illegal to be called. Deleted explicitly to let the compiler detect any violation */

--- a/ridlbe/c++11/templates/cli/hdr/interface_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_post.erb
@@ -24,7 +24,7 @@ protected:
   <%= cxxname %> () = default;
 #endif /* _MSC_VER < 1920 */
   <%= cxxname %> (TAOX11_NAMESPACE::Abstractbase_proxy_ptr prx);
-  ~<%= cxxname %> () = default;
+  virtual ~<%= cxxname %> () = default;
   /// Required for derived value types
   <%= cxxname %>(const <%= cxxname %>&) = default;
   <%= cxxname %>(<%= cxxname %>&&) = default;
@@ -50,7 +50,7 @@ protected:
   /// Default constructor
   <%= cxxname %> () = default;
   /// Destructor
-  ~<%= cxxname %> () = default;
+  virtual ~<%= cxxname %> () = default;
 
 %   if needs_abstract_base_overrides?
   // from CORBA::AbstractBase
@@ -83,7 +83,7 @@ protected:
   <%= cxxname %> () = default;
 #endif /* _MSC_VER < 1920 */
   /// Destructor
-  ~<%= cxxname %> () = default;
+  virtual ~<%= cxxname %> () = default;
 
   /// Returns a strong client reference for the local object you are calling
   <%= scoped_cxx_return_type %> _this ();

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_init.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_init.erb
@@ -34,7 +34,7 @@ public:
 
 protected:
   <%= factory_cxxname %> () = default;
-  ~<%= factory_cxxname %> () = default;
+  virtual ~<%= factory_cxxname %> () = default;
   <%= factory_cxxname %> (const <%= factory_cxxname %>&) = default;
   <%= factory_cxxname %> (<%= factory_cxxname %>&&) = default;
 }; // class <%= factory_cxxname %>

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb
@@ -17,7 +17,7 @@ namespace obv
 #else
     <%= cxxname %> () = default;
 #endif /* _MSC_VER < 1920 */
-    ~<%= cxxname %> () = default;
+    virtual ~<%= cxxname %> () = default;
     <%= cxxname %> (const <%= cxxname %>&) = default;
     <%= cxxname %> (<%= cxxname %>&&) = default;
 % if member_count > 0

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_pre.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_pre.erb
@@ -56,7 +56,7 @@ protected:
 % else
   <%= cxxname %> () = default;
 % end
-  ~<%= cxxname %> () = default;
+  virtual ~<%= cxxname %> () = default;
   <%= cxxname %> (const <%= cxxname %>&) = default;
   <%= cxxname %> (<%= cxxname %>&&) = default;
   <%= cxxname %>& operator= (const <%= cxxname %>&) = delete;


### PR DESCRIPTION
    * ridlbe/c++11/templates/cli/hdr/ami/interface_amic_post.erb:
    * ridlbe/c++11/templates/cli/hdr/interface_post.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_init.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_pre.erb: