### PR TITLE
Remove redundant is_local checks, already done in ServantHeaderWriter

### DIFF
--- a/ridlbe/c++11/templates/srv/hdr/interface_post.erb
+++ b/ridlbe/c++11/templates/srv/hdr/interface_post.erb
@@ -1,5 +1,3 @@
-% unless is_local?
-
   private:
     // generated from <%= ridl_template_path %>
     /** @name Illegal to be called. Deleted explicitly to let the compiler detect any violation */
@@ -15,4 +13,3 @@
   };
 
 } // namespace POA
-% end

--- a/ridlbe/c++11/templates/srv/hdr/interface_pre.erb
+++ b/ridlbe/c++11/templates/srv/hdr/interface_pre.erb
@@ -1,5 +1,3 @@
-% unless is_local?
-
 // generated from <%= ridl_template_path %>
 namespace POA
 {
@@ -67,4 +65,3 @@ namespace POA
     //@}
 %     end
 %   end
-% end


### PR DESCRIPTION
    * ridlbe/c++11/templates/srv/hdr/interface_post.erb:
    * ridlbe/c++11/templates/srv/hdr/interface_pre.erb: