### PR TITLE
We first have to apply the implied AMI IDL rules, after that the C++ …

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/ami/attribute.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/attribute.erb
@@ -3,16 +3,16 @@
 /// @copydoc <%= doc_scoped_name %>
 //@{
 void
-get_<%= cxxname %> (<%= scoped_cxx_in_type %> ami_return_val);
+get_<%= name %> (<%= scoped_cxx_in_type %> ami_return_val);
 
 void
-get_<%= cxxname %>_excep (IDL::traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder);
+get_<%= name %>_excep (IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder);
 % unless is_readonly?
 
 void
-set_<%= cxxname %> ();
+set_<%= name %> ();
 
 void
-set_<%= cxxname %>_excep (IDL::traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder);
+set_<%= name %>_excep (IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder);
 % end
 //@}

--- a/ridlbe/c++11/templates/cli/hdr/ami/attribute_amic.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/attribute_amic.erb
@@ -1,12 +1,12 @@
 
 // generated from <%= ridl_template_path %>
 void
-<%= sendc_prefix_get %><%= cxxname %> (
+<%= sendc_prefix_get %><%= name %> (
     <%= interface.handler_scoped_cxx_in_type %> ami_handler);
 % unless is_readonly?
 
 void
-<%= sendc_prefix_set %><%= cxxname %> (
+<%= sendc_prefix_set %><%= name %> (
     <%= interface.handler_scoped_cxx_in_type %> ami_handler,
     <%= cxx_in_type %> _x11_<%= cxxname %>);
 % end

--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_object_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_object_traits.erb
@@ -16,14 +16,14 @@ namespace TAOX11_NAMESPACE
     template<>
     <%= amic_export_macro %>object_traits< <%= amic_scoped_cxxtype %>>::ref_type
     object_traits< <%= amic_scoped_cxxtype %>>::narrow (
-      object_traits< TAOX11_NAMESPACE::CORBA::Object>::ref_type);
+      object_traits<TAOX11_NAMESPACE::CORBA::Object>::ref_type);
 %   else
 %     if declare_local_object_narrow_specialization?
 
     template<>
     <%= amic_export_macro %>object_traits< <%= amic_scoped_cxxtype %>>::ref_type
     object_traits< <%= amic_scoped_cxxtype %>>::narrow (
-       object_traits< TAOX11_NAMESPACE::CORBA::Object>::ref_type);
+       object_traits<TAOX11_NAMESPACE::CORBA::Object>::ref_type);
 %     end
 %   end
   } // namespace CORBA

--- a/ridlbe/c++11/templates/cli/hdr/ami/operation.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/operation.erb
@@ -12,5 +12,4 @@ void
 %   end
 
 void
-<%= cxxname %>_excep (
-    IDL::traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder);
+<%= name %>_excep (IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder);

--- a/ridlbe/c++11/templates/cli/hdr/ami/operation_amic.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/operation_amic.erb
@@ -1,7 +1,7 @@
 // generated from <%= ridl_template_path %>
 %   _args = in_arguments.dup
 void
-<%= sendc_prefix %><%= cxxname %> (
+<%= sendc_prefix %><%= name %> (
     <%= interface.handler_scoped_cxx_in_type %> ami_handler<%= _args.empty? ? ');' : ',' %>
 %   while !_args.empty?
 %     _arg = _args.shift

--- a/ridlbe/c++11/templates/cli/prx/ami/attribute.erb
+++ b/ridlbe/c++11/templates/cli/prx/ami/attribute.erb
@@ -1,13 +1,12 @@
 
 // generated from <%= ridl_template_path %>
-static void get_<%= cxxname %>_reply_stub (
+static void get_<%= name %>_reply_stub (
       TAO_InputCDR &_tao_reply_cdr,
       TAO_MESSAGING::ReplyHandler_ptr _tao_reply_handler,
       TAO_CORBA::ULong reply_status);
-
 % unless is_readonly?
 
-static void set_<%= cxxname %>_reply_stub (
+static void set_<%= name %>_reply_stub (
       TAO_InputCDR &_tao_reply_cdr,
       TAO_MESSAGING::ReplyHandler_ptr _reply_handler,
       TAO_CORBA::ULong reply_status);

--- a/ridlbe/c++11/templates/cli/prx/ami/operation.erb
+++ b/ridlbe/c++11/templates/cli/prx/ami/operation.erb
@@ -1,5 +1,5 @@
 // generated from <%= ridl_template_path %>
-static void <%= cxxname %>_reply_stub (
+static void <%= name %>_reply_stub (
       TAO_InputCDR &_tao_reply_cdr,
       TAO_MESSAGING::ReplyHandler_ptr _tao_reply_handler,
       TAO_CORBA::ULong reply_status);

--- a/ridlbe/c++11/templates/cli/src/ami/attribute.erb
+++ b/ridlbe/c++11/templates/cli/src/ami/attribute.erb
@@ -1,7 +1,7 @@
 % unless interface.is_local?
 // generated from <%= ridl_template_path %>
 void
-<%= interface.cxxname %>::get_<%= cxxname %> (
+<%= interface.cxxname %>::get_<%= name %> (
     <%= scoped_cxx_in_type %> ami_return_val)
 {
 %   if interface.is_abstract?
@@ -84,15 +84,15 @@ void
 
 
 void
-<%= interface.proxy_cxxname %>::get_<%= cxxname %>_reply_stub (
+<%= interface.proxy_cxxname %>::get_<%= name %>_reply_stub (
     TAO_InputCDR &_tao_in,
     TAO_MESSAGING::ReplyHandler_ptr _tao_reply_handler,
     uint32_t reply_status)
 {
   // Retrieve Reply Handler object.
-  ::TAOX11_NAMESPACE::CORBA::object_traits< ::TAOX11_NAMESPACE::CORBA::Object>::ref_type _reply_handler_obj =
-    ::TAOX11_NAMESPACE::CORBA::make_reference< TAOX11_CORBA::Object> (
-      new ::TAOX11_NAMESPACE::Object_proxy (TAO_MESSAGING::ReplyHandler::_duplicate (_tao_reply_handler)));
+  TAOX11_NAMESPACE::CORBA::object_traits<TAOX11_NAMESPACE::CORBA::Object>::ref_type _reply_handler_obj =
+    TAOX11_NAMESPACE::CORBA::make_reference<TAOX11_CORBA::Object> (
+      new TAOX11_NAMESPACE::Object_proxy (TAO_MESSAGING::ReplyHandler::_duplicate (_tao_reply_handler)));
 
   <%= interface.scoped_cxx_traits_type %>::ref_type _reply_handler =
     <%= interface.scoped_cxx_traits_type %>::narrow (std::move(_reply_handler_obj));
@@ -105,10 +105,10 @@ void
       // Demarshall all the arguments.
       <%= scoped_cxx_member_type %> _taox11_ami_return_val;
       if (!(_tao_in >> <%= cdr_to_fmt % "_taox11_ami_return_val" %>))
-        throw ::TAOX11_NAMESPACE::CORBA::MARSHAL ();
+        throw TAOX11_NAMESPACE::CORBA::MARSHAL ();
 
       // Invoke the call back method.
-      _reply_handler->get_<%= cxxname %> (_taox11_ami_return_val);
+      _reply_handler->get_<%= name %> (_taox11_ami_return_val);
       break;
     }
     case TAO_AMI_REPLY_USER_EXCEPTION:
@@ -145,8 +145,8 @@ void
       TAOX11_NAMESPACE::CORBA::OctetSeq const _marshaled_exception =
         seq_to_x11<TAOX11_NAMESPACE::CORBA::OctetSeq> (_tao_marshaled_exception);
 
-      IDL::traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type _exception_holder =
-        TAOX11_NAMESPACE::CORBA::make_reference< ::TAOX11_NAMESPACE::ExceptionHolder_i> (
+      IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type _exception_holder =
+        TAOX11_NAMESPACE::CORBA::make_reference<TAOX11_NAMESPACE::ExceptionHolder_i> (
           reply_status == TAO_AMI_REPLY_SYSTEM_EXCEPTION,
           _tao_in.byte_order (),
           _marshaled_exception,
@@ -159,7 +159,7 @@ void
           _tao_in.char_translator (),
           _tao_in.wchar_translator ());
 
-      _reply_handler->get_<%= cxxname %>_excep (std::move(_exception_holder));
+      _reply_handler->get_<%= name %>_excep (std::move(_exception_holder));
       break;
     }
     //TODO
@@ -171,8 +171,8 @@ void
 }
 
 void
-<%= interface.cxxname %>::get_<%= cxxname %>_excep (
-    IDL::traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder)
+<%= interface.cxxname %>::get_<%= name %>_excep (
+    IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder)
 {
   if (!this-><%= interface.proxy_cxxname.downcase %>_->is_evaluated ())
   {
@@ -232,7 +232,7 @@ void
 
 %   unless is_readonly?
 void
-<%= interface.cxxname %>::set_<%= cxxname %> ()
+<%= interface.cxxname %>::set_<%= name %> ()
 {
 %   if interface.is_abstract?
   if (!this->_is_object ())
@@ -313,15 +313,15 @@ void
 }
 
 void
-<%= interface.proxy_cxxname %>::set_<%= cxxname %>_reply_stub (
+<%= interface.proxy_cxxname %>::set_<%= name %>_reply_stub (
     TAO_InputCDR &_tao_in,
     TAO_MESSAGING::ReplyHandler_ptr _tao_reply_handler,
     TAO_CORBA::ULong reply_status)
 {
   // Retrieve Reply Handler object.
-  ::TAOX11_NAMESPACE::CORBA::object_traits< ::TAOX11_NAMESPACE::CORBA::Object>::ref_type _reply_handler_obj =
-    ::TAOX11_NAMESPACE::CORBA::make_reference< TAOX11_CORBA::Object> (
-      new ::TAOX11_NAMESPACE::Object_proxy (TAO_MESSAGING::ReplyHandler::_duplicate (_tao_reply_handler)));
+  TAOX11_NAMESPACE::CORBA::object_traits<TAOX11_NAMESPACE::CORBA::Object>::ref_type _reply_handler_obj =
+    TAOX11_NAMESPACE::CORBA::make_reference<TAOX11_CORBA::Object> (
+      new TAOX11_NAMESPACE::Object_proxy (TAO_MESSAGING::ReplyHandler::_duplicate (_tao_reply_handler)));
 
   <%= interface.scoped_cxx_traits_type %>::ref_type _reply_handler =
     <%= interface.scoped_cxx_traits_type %>::narrow (std::move(_reply_handler_obj));
@@ -332,7 +332,7 @@ void
     case TAO_AMI_REPLY_OK:
     {
       // Invoke the call back method.
-      _reply_handler->set_<%= cxxname %> ();
+      _reply_handler->set_<%= name %> ();
       break;
     }
     case TAO_AMI_REPLY_USER_EXCEPTION:
@@ -368,8 +368,8 @@ void
       TAOX11_NAMESPACE::CORBA::OctetSeq const _marshaled_exception =
         seq_to_x11<TAOX11_NAMESPACE::CORBA::OctetSeq> (_tao_marshaled_exception);
 
-      IDL::traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type _exception_holder =
-        TAOX11_NAMESPACE::CORBA::make_reference< ::TAOX11_NAMESPACE::ExceptionHolder_i> (
+      IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type _exception_holder =
+        TAOX11_NAMESPACE::CORBA::make_reference<TAOX11_NAMESPACE::ExceptionHolder_i> (
           reply_status == TAO_AMI_REPLY_SYSTEM_EXCEPTION,
           _tao_in.byte_order (),
           _marshaled_exception,
@@ -382,7 +382,7 @@ void
           _tao_in.char_translator (),
           _tao_in.wchar_translator ());
 
-      _reply_handler->set_<%= cxxname %>_excep (std::move(_exception_holder));
+      _reply_handler->set_<%= name %>_excep (std::move(_exception_holder));
       break;
     }
     //TODO
@@ -394,8 +394,8 @@ void
 }
 
 void
-<%= interface.cxxname %>::set_<%= cxxname %>_excep (
-    IDL::traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder)
+<%= interface.cxxname %>::set_<%= name %>_excep (
+    IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder)
 {
   if (!this-><%= interface.proxy_cxxname.downcase %>_->is_evaluated ())
   {

--- a/ridlbe/c++11/templates/cli/src/ami/attribute_amic.erb
+++ b/ridlbe/c++11/templates/cli/src/ami/attribute_amic.erb
@@ -2,7 +2,7 @@
 
 // generated from <%= ridl_template_path %>
 void
-<%= interface.amic_scoped_cxxname %>::<%= sendc_prefix_get %><%= cxxname %>(
+<%= interface.amic_scoped_cxxname %>::<%= sendc_prefix_get %><%= name %>(
     <%= interface.handler_scoped_cxx_in_type %> ami_handler)
 {
 %   if interface.is_abstract?
@@ -49,19 +49,19 @@ void
 
       if (TAO_CORBA::is_nil (_tao_ami_handler))
       {
-        TAOX11_LOG_ERROR ("<%= interface.scoped_cxxname %>::<%= sendc_prefix_get %><%= cxxname %> ERROR.");
+        TAOX11_LOG_ERROR ("<%= interface.scoped_cxxname %>::<%= sendc_prefix_get %><%= name %> ERROR.");
       }
     }
     _tao_call.invoke (
       _tao_ami_handler,
-      <%= interface.handler_proxy_cxxname %>::get_<%= cxxname %>_reply_stub);
+      <%= interface.handler_proxy_cxxname %>::get_<%= name %>_reply_stub);
   }
   catch_tao_system_ex(_ex)
 }
 
 %   unless is_readonly?
 void
-<%= interface.amic_scoped_cxxname %>::<%= sendc_prefix_set %><%= cxxname %>(
+<%= interface.amic_scoped_cxxname %>::<%= sendc_prefix_set %><%= name %>(
     <%= interface.handler_scoped_cxx_in_type %> ami_handler,
     <%= cxx_in_type %> _x11_<%= cxxname %>)
 {
@@ -118,13 +118,13 @@ void
 
       if (TAO_CORBA::is_nil (_tao_ami_handler))
       {
-        TAOX11_LOG_ERROR ("<%= interface.scoped_cxxname %>::<%= sendc_prefix_set %><%= cxxname %> ERROR.");
+        TAOX11_LOG_ERROR ("<%= interface.scoped_cxxname %>::<%= sendc_prefix_set %><%= name %> ERROR.");
       }
     }
 
     _tao_call.invoke (
       _tao_ami_handler,
-      <%= interface.handler_proxy_cxxname %>::set_<%= cxxname %>_reply_stub);
+      <%= interface.handler_proxy_cxxname %>::set_<%= name %>_reply_stub);
   }
   catch_tao_system_ex(_ex)
 }

--- a/ridlbe/c++11/templates/cli/src/ami/operation.erb
+++ b/ridlbe/c++11/templates/cli/src/ami/operation.erb
@@ -131,14 +131,14 @@ void
 
 
 void
-<%= interface.proxy_cxxname %>::<%= cxxname %>_reply_stub (
+<%= interface.proxy_cxxname %>::<%= name %>_reply_stub (
     TAO_InputCDR &_tao_in,
     TAO_MESSAGING::ReplyHandler_ptr _tao_reply_handler,
     TAO_CORBA::ULong reply_status)
 {
   // Retrieve Reply Handler object.
-  ::TAOX11_NAMESPACE::CORBA::object_traits< ::TAOX11_NAMESPACE::CORBA::Object>::ref_type _reply_handler_obj =
-    ::TAOX11_NAMESPACE::CORBA::make_reference< TAOX11_CORBA::Object> (
+  TAOX11_NAMESPACE::CORBA::object_traits<TAOX11_NAMESPACE::CORBA::Object>::ref_type _reply_handler_obj =
+    TAOX11_NAMESPACE::CORBA::make_reference<TAOX11_CORBA::Object> (
       new TAOX11_NAMESPACE::Object_proxy (TAO_MESSAGING::ReplyHandler::_duplicate (_tao_reply_handler)));
 
   <%= interface.scoped_cxx_traits_type %>::ref_type _reply_handler =
@@ -153,7 +153,7 @@ void
 %   unless is_oneway? || is_void?
       <%= scoped_cxx_member_type %> _taox11_ami_return_val;
       if (!(_tao_in >> <%= cdr_to_fmt % "_taox11_ami_return_val" %>))
-        throw ::TAOX11_NAMESPACE::CORBA::MARSHAL ();
+        throw TAOX11_NAMESPACE::CORBA::MARSHAL ();
 
 %   end
 %   arguments.each do |_arg|
@@ -161,12 +161,12 @@ void
 %     when :out
       <%= _arg.scoped_cxx_member_type %> _<%= _arg.cxxname %>;
       if (!(_tao_in >> <%= _arg.cdr_to_fmt % "_#{_arg.cxxname}" %>))
-        throw ::TAOX11_NAMESPACE::CORBA::MARSHAL ();
+        throw TAOX11_NAMESPACE::CORBA::MARSHAL ();
 
 %     when :inout
       <%= _arg.scoped_cxx_member_type %> _<%= _arg.cxxname %>;
       if (!(_tao_in >> <%= _arg.cdr_to_fmt % "_#{_arg.cxxname}" %>))
-        throw ::TAOX11_NAMESPACE::CORBA::MARSHAL ();
+        throw TAOX11_NAMESPACE::CORBA::MARSHAL ();
 
 %     end
 %   end
@@ -225,8 +225,8 @@ void
       TAOX11_NAMESPACE::CORBA::OctetSeq const _marshaled_exception =
         seq_to_x11<TAOX11_NAMESPACE::CORBA::OctetSeq> (_tao_marshaled_exception);
 
-      IDL::traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type _exception_holder =
-        TAOX11_NAMESPACE::CORBA::make_reference< ::TAOX11_NAMESPACE::ExceptionHolder_i> (reply_status == TAO_AMI_REPLY_SYSTEM_EXCEPTION,
+      IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type _exception_holder =
+        TAOX11_NAMESPACE::CORBA::make_reference<TAOX11_NAMESPACE::ExceptionHolder_i> (reply_status == TAO_AMI_REPLY_SYSTEM_EXCEPTION,
                                  _tao_in.byte_order (),
                                  _marshaled_exception,
 %   if has_raises?
@@ -238,7 +238,7 @@ void
                                  _tao_in.char_translator (),
                                  _tao_in.wchar_translator ());
 
-      _reply_handler-><%= cxxname %>_excep (std::move(_exception_holder));
+      _reply_handler-><%= name %>_excep (std::move(_exception_holder));
       break;
     }
     //TODO
@@ -250,8 +250,8 @@ void
 }
 
 void
-<%= interface.cxxname %>::<%= cxxname %>_excep (
-    IDL::traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder)
+<%= interface.cxxname %>::<%= name %>_excep (
+    IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder)
 {
   if (!this-><%= interface.proxy_cxxname.downcase %>_->is_evaluated ())
     {

--- a/ridlbe/c++11/templates/cli/src/ami/operation_amic.erb
+++ b/ridlbe/c++11/templates/cli/src/ami/operation_amic.erb
@@ -3,7 +3,7 @@
 // generated from <%= ridl_template_path %>
 %     _args = in_arguments.dup
 void
-<%= interface.amic_scoped_cxxname %>::<%= sendc_prefix %><%= cxxname %> (
+<%= interface.amic_scoped_cxxname %>::<%= sendc_prefix %><%= name %> (
     <%= interface.handler_scoped_cxx_in_type %> ami_handler<%= _args.empty? ? ')' : ',' %>
 %     while !_args.empty?
 %       _arg = _args.shift
@@ -91,14 +91,14 @@ void
 
       if (TAO_CORBA::is_nil (_tao_ami_handler))
       {
-        TAOX11_LOG_ERROR ("<%= interface.scoped_cxxname %>::<%= sendc_prefix %><%= cxxname %> ERROR.");
+        TAOX11_LOG_ERROR ("<%= interface.scoped_cxxname %>::<%= sendc_prefix %><%= name %> ERROR.");
       }
     }
 %#  else _tao_ami_handler is a nullptr
 
     _tao_call.invoke (
       _tao_ami_handler,
-      <%= interface.handler_proxy_cxxname %>::<%= cxxname %>_reply_stub);
+      <%= interface.handler_proxy_cxxname %>::<%= name %>_reply_stub);
   }
   catch_tao_system_ex(_ex)
 }

--- a/ridlbe/c++11/templates/srv/hdr/ami/attribute.erb
+++ b/ridlbe/c++11/templates/srv/hdr/ami/attribute.erb
@@ -1,16 +1,16 @@
 
 // generated from <%= ridl_template_path %>
 virtual void
-get_<%= cxxname %> (<%= scoped_cxx_in_type %> ami_return_val) = 0;
+get_<%= name %> (<%= scoped_cxx_in_type %> ami_return_val) = 0;
 
 virtual void
-get_<%= cxxname %>_excep (IDL::traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder) = 0;
+get_<%= name %>_excep (IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder) = 0;
 
 % unless is_readonly?
 virtual void
-set_<%= cxxname %> () = 0;
+set_<%= name %> () = 0;
 
 virtual void
-set_<%= cxxname %>_excep (IDL::traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder) = 0;
+set_<%= name %>_excep (IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder) = 0;
 
 % end

--- a/ridlbe/c++11/templates/srv/hdr/ami/operation.erb
+++ b/ridlbe/c++11/templates/srv/hdr/ami/operation.erb
@@ -2,7 +2,7 @@
 // generated from <%= ridl_template_path %>
 % _args = out_arguments.dup
 virtual void
-<%= cxxname %> (<% if is_void? && _args.empty? %>)= 0;<% end %>
+<%= cxxname %> (<% if is_void? && _args.empty? %>) = 0;<% end %>
 %   unless is_void?
     <%= scoped_cxx_in_type %> ami_return_val<%= _args.empty? ? ') = 0;' : ',' %>
 %   end
@@ -12,4 +12,4 @@ virtual void
 %   end
 
 virtual void
-<%= cxxname %>_excep (IDL::traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder) = 0;
+<%= name %>_excep (IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder) = 0;

--- a/ridlbe/c++11/templates/srv/src/ami/attribute.erb
+++ b/ridlbe/c++11/templates/srv/src/ami/attribute.erb
@@ -32,7 +32,7 @@ void <%= interface.scoped_srvproxy_cxxname %>::get_<%= name %>_skel (
     [&]() {
       PS::SArg_Traits< <%= scoped_cxx_arg_type %>>::in_arg_type arg_1 =
         PS::get_in_arg< <%= scoped_cxx_arg_type %>> (server_request.operation_details (), args, 1);
-      servant.get_<%= cxxname %> (arg_1);
+      servant.get_<%= name %> (arg_1);
     } );
 
   TAO_TAO::Upcall_Wrapper upcall_wrapper;
@@ -72,8 +72,8 @@ void <%= interface.scoped_srvproxy_cxxname %>::get_<%= name %>_excep_skel (
 #endif /* TAO_HAS_INTERCEPTORS */
 
 % end
-  PS::SArg_Traits< void >::ret_val retval;
-  PS::SArg_Traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder >::in_arg_val _tao_excep_holder;
+  PS::SArg_Traits<void>::ret_val retval;
+  PS::SArg_Traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::in_arg_val _tao_excep_holder;
 
   TAO_TAO::Argument * const args[] =
   {
@@ -83,9 +83,9 @@ void <%= interface.scoped_srvproxy_cxxname %>::get_<%= name %>_excep_skel (
 
   TAOX11_NAMESPACE::Upcall_Command command (
     [&]() {
-      PS::SArg_Traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder >::in_arg_type arg_1 =
-        std::move (PS::get_in_arg< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder> (server_request.operation_details (), args, 1));
-      servant.get_<%= cxxname %>_excep (arg_1);
+      PS::SArg_Traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::in_arg_type arg_1 =
+        std::move (PS::get_in_arg<TAOX11_NAMESPACE::Messaging::ExceptionHolder> (server_request.operation_details (), args, 1));
+      servant.get_<%= name %>_excep (arg_1);
     } );
 
   TAO_TAO::Upcall_Wrapper upcall_wrapper;
@@ -135,7 +135,7 @@ void <%= interface.scoped_srvproxy_cxxname %>::set_<%= name %>_skel (
 
   TAOX11_NAMESPACE::Upcall_Command command (
     [&]() {
-      servant.set_<%= cxxname %> ();
+      servant.set_<%= name %> ();
     } );
 
   TAO_TAO::Upcall_Wrapper upcall_wrapper;
@@ -174,8 +174,8 @@ void <%= interface.scoped_srvproxy_cxxname %>::set_<%= name %>_excep_skel (
 #endif /* TAO_HAS_INTERCEPTORS */
 
 % end
-  PS::SArg_Traits< void >::ret_val retval;
-  PS::SArg_Traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder >::in_arg_val _tao_excep_holder;
+  PS::SArg_Traits<void>::ret_val retval;
+  PS::SArg_Traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::in_arg_val _tao_excep_holder;
 
   TAO_TAO::Argument * const args[] =
   {
@@ -185,9 +185,9 @@ void <%= interface.scoped_srvproxy_cxxname %>::set_<%= name %>_excep_skel (
 
   TAOX11_NAMESPACE::Upcall_Command command (
     [&]() {
-      PS::SArg_Traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder >::in_arg_type arg_1 =
-        std::move (PS::get_in_arg< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder> (server_request.operation_details (), args, 1));
-      servant.set_<%= cxxname %>_excep (arg_1);
+      PS::SArg_Traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::in_arg_type arg_1 =
+        std::move (PS::get_in_arg<TAOX11_NAMESPACE::Messaging::ExceptionHolder> (server_request.operation_details (), args, 1));
+      servant.set_<%= name %>_excep (arg_1);
     } );
 
   TAO_TAO::Upcall_Wrapper upcall_wrapper;

--- a/ridlbe/c++11/templates/srv/src/ami/exceptionholder_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/ami/exceptionholder_traits.erb
@@ -8,10 +8,10 @@
   {
     // Arg traits specializations.
     template<>
-    class SArg_Traits< TAOX11_NAMESPACE::Messaging::ExceptionHolder>
+    class SArg_Traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>
     : public
         Basic_SArg_Traits_T<
-            TAOX11_IDL::traits< TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type,
+            TAOX11_IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type,
             Any_Insert_Policy_Stream>
     {
     };

--- a/ridlbe/c++11/templates/srv/src/ami/operation.erb
+++ b/ridlbe/c++11/templates/srv/src/ami/operation.erb
@@ -132,8 +132,8 @@ void <%= interface.scoped_srvproxy_cxxname %>::<%= name %>_excep_skel (
 #endif /* TAO_HAS_INTERCEPTORS */
 
 % end
-  PS::SArg_Traits< void >::ret_val retval;
-  PS::SArg_Traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder >::in_arg_val _tao_excep_holder;
+  PS::SArg_Traits<void>::ret_val retval;
+  PS::SArg_Traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::in_arg_val _tao_excep_holder;
 
   TAO_TAO::Argument * const args[] =
   {
@@ -143,9 +143,9 @@ void <%= interface.scoped_srvproxy_cxxname %>::<%= name %>_excep_skel (
 
   TAOX11_NAMESPACE::Upcall_Command command (
     [&]() {
-      PS::SArg_Traits< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder >::in_arg_type arg_1 =
-        std::move (PS::get_in_arg< ::TAOX11_NAMESPACE::Messaging::ExceptionHolder> (server_request.operation_details (), args, 1));
-      servant.<%= cxxname %>_excep (arg_1);
+      PS::SArg_Traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::in_arg_type arg_1 =
+        std::move (PS::get_in_arg<TAOX11_NAMESPACE::Messaging::ExceptionHolder> (server_request.operation_details (), args, 1));
+      servant.<%= name %>_excep (arg_1);
     } );
 
   TAO_TAO::Upcall_Wrapper upcall_wrapper;

--- a/ridlbe/c++11/visitors/mixins/ami_names.rb
+++ b/ridlbe/c++11/visitors/mixins/ami_names.rb
@@ -50,7 +50,7 @@ module IDL
       end
 
       def amic_scoped_cxx_in_type
-         @amic_scoped_cxx_in_type ||= ('TAOX11_CORBA::amic_traits< '+scoped_cxxtype+'>::in_type')
+         @amic_scoped_cxx_in_type ||= ('CORBA::amic_traits< '+scoped_cxxtype+'>::in_type')
       end
 
       def handler_scoped_cxxname
@@ -63,15 +63,15 @@ module IDL
       end
 
       def handler_scoped_cxx_in_type
-         @handler_scoped_cxx_in_type ||= ('TAOX11_IDL::traits<'+handler_scoped_cxxname+'>::ref_type')
+         @handler_scoped_cxx_in_type ||= ('IDL::traits<'+handler_scoped_cxxname+'>::ref_type')
       end
 
       def handler_scoped_cxx_out_type
-         @handler_scoped_cxx_out_type ||= ('TAOX11_IDL::traits<'+handler_scoped_cxxname+'>::ref_type&')
+         @handler_scoped_cxx_out_type ||= ('IDL::traits<'+handler_scoped_cxxname+'>::ref_type&')
       end
 
       def handler_scoped_cxx_move_type
-        @handler_scoped_cxx_move_type ||= ('TAOX11_IDL::traits<'+handler_scoped_cxxname+'>::ref_type&&')
+        @handler_scoped_cxx_move_type ||= ('IDL::traits<'+handler_scoped_cxxname+'>::ref_type&&')
       end
 
       def handler_skel_cxxname

--- a/tests/ami_test/ami_naming/client.cpp
+++ b/tests/ami_test/ami_naming/client.cpp
@@ -230,37 +230,37 @@ public:
      result = 1;
    }
 
-   void get__cxx_do (int32_t res) override
+   void get_do (int32_t res) override
    {
      callback_attrib++;
-     TAOX11_TEST_INFO << "Callback method <get__cxx_do> called: res " << res
+     TAOX11_TEST_INFO << "Callback method <get_do> called: res " << res
                  << std::endl;
      if (res != 110)
        {
          TAOX11_TEST_ERROR
-            << "ERROR: Callback method <get__cxx_do> ami_return_val not 110: "
+            << "ERROR: Callback method <get_do> ami_return_val not 110: "
             << res << std::endl;
          result = 1;
        }
    }
 
-   void get__cxx_do_excep (
+   void get_do_excep (
        IDL::traits< ::Messaging::ExceptionHolder>::ref_type) override
    {
-     TAOX11_TEST_INFO << "Error, Unexpected callback method <get__cxx_do_excep> called."
+     TAOX11_TEST_INFO << "Error, Unexpected callback method <get_do_excep> called."
                  << std::endl;
      result = 1;
    }
 
-   void set__cxx_do () override
+   void set_do () override
    {
      callback_attrib++;
-     TAOX11_TEST_INFO << "Callback method <set__cxx_do> called:"<< std::endl;
+     TAOX11_TEST_INFO << "Callback method <set_do> called:"<< std::endl;
    }
 
-   void set__cxx_do_excep (IDL::traits< ::Messaging::ExceptionHolder>::ref_type) override
+   void set_do_excep (IDL::traits< ::Messaging::ExceptionHolder>::ref_type) override
    {
-     TAOX11_TEST_INFO << "Error, Unexpected callback method <set__cxx_do_excep> called."
+     TAOX11_TEST_INFO << "Error, Unexpected callback method <set_do_excep> called."
                  << std::endl;
      result = 1;
    }
@@ -309,7 +309,7 @@ public:
       }
   }
 
-  void _cxx_do_excep (IDL::traits< ::Messaging::ExceptionHolder>::ref_type) override
+  void do_excep (IDL::traits< ::Messaging::ExceptionHolder>::ref_type) override
   {
     TAOX11_TEST_INFO << "Error, Unexpected callback method <_cxx_do_excep> called."
                 << std::endl;
@@ -599,7 +599,7 @@ int main(int argc, char* argv[])
       a_async_two->sendc_foo_two (two_handler,9);
 
       TAOX11_TEST_INFO << "Client: Sending asynch message for do." << std::endl;
-      a_async_two->sendc__cxx_do (two_handler,10);
+      a_async_two->sendc_do (two_handler,10);
 
       TAOX11_TEST_INFO << "Client: Sending asynch message for yadda, sendc_get_yadda,sendc_ami_get_yadda." << std::endl;
       //yadda
@@ -615,8 +615,8 @@ int main(int argc, char* argv[])
 
       TAOX11_TEST_INFO << "Client: Sending asynch message for attribute do." << std::endl;
       //do
-      a_async->sendc_set__cxx_do (test_handler, 100);
-      a_async->sendc_get__cxx_do (test_handler);
+      a_async->sendc_set_do (test_handler, 100);
+      a_async->sendc_get_do (test_handler);
 
       TAOX11_TEST_INFO << "Client: Sending the last  asynch message foo." << std::endl;
       a_async->sendc_ami_ami_foo (test_handler, 10);

--- a/tests/ami_test/keywords/client.cpp
+++ b/tests/ami_test/keywords/client.cpp
@@ -59,7 +59,7 @@ Handler::_cxx_uint32_t (int16_t ami_return_val)
 }
 
 void
-Handler::_cxx_uint32_t_excep (
+Handler::uint32_t_excep (
   IDL::traits< ::Messaging::ExceptionHolder>::ref_type)
 {
   ++result_;
@@ -405,6 +405,64 @@ Handler::shutdown_excep (
 {
 }
 
+void
+Handler::_cxx_class ()
+{
+  ++result_;
+  TAOX11_TEST_ERROR << "ERROR : Unexpected invocation of '_cxx_class'" << std::endl;
+}
+
+void
+Handler::class_excep (IDL::traits< ::Messaging::ExceptionHolder>::ref_type)
+{
+  ++result_;
+  TAOX11_TEST_ERROR << "ERROR : Unexpected invocation of 'class_excep'" << std::endl;
+}
+
+void
+Handler::_cxx_void (
+    const std::string&,
+    const std::string&)
+{
+  ++result_;
+  TAOX11_TEST_ERROR << "ERROR : Unexpected invocation of '_cxx_void'" << std::endl;
+}
+
+void
+Handler::void_excep (IDL::traits< ::Messaging::ExceptionHolder>::ref_type)
+{
+  ++result_;
+  TAOX11_TEST_ERROR << "ERROR : Unexpected invocation of 'void_excep'" << std::endl;
+}
+
+void
+Handler::get_private (::Test::_cxx_bool)
+{
+  ++result_;
+  TAOX11_TEST_ERROR << "ERROR : Unexpected invocation of 'get_private'" << std::endl;
+}
+
+void
+Handler::get_private_excep (IDL::traits< ::Messaging::ExceptionHolder>::ref_type)
+{
+  ++result_;
+  TAOX11_TEST_ERROR << "ERROR : Unexpected invocation of 'get_private_excep'" << std::endl;
+}
+
+void
+Handler::set_private ()
+{
+  ++result_;
+  TAOX11_TEST_ERROR << "ERROR : Unexpected invocation of 'set_private'" << std::endl;
+}
+
+void
+Handler::set_private_excep (IDL::traits< ::Messaging::ExceptionHolder>::ref_type)
+{
+  ++result_;
+  TAOX11_TEST_ERROR << "ERROR : Unexpected invocation of 'set_private_excep'" << std::endl;
+}
+
 int main(int argc, char* argv[])
 {
   try
@@ -504,7 +562,7 @@ int main(int argc, char* argv[])
       hello->sendc_inout_bool(test_handler, Test::_cxx_bool::_cxx_char,  bool_inout);
       Test::_cxx_int16_t int16_t_inout;
       hello->sendc_inout_int16_t(test_handler, Test::_cxx_int16_t::double_, int16_t_inout);
-      hello->sendc__cxx_uint32_t (test_handler, 10);
+      hello->sendc_uint32_t (test_handler, 10);
 
       TAOX11_TEST_DEBUG << "Setting the attributes asynchronously." << std::endl;
       hello->sendc_set_attr_bool (test_handler, Test::_cxx_bool::_cxx_char);

--- a/tests/ami_test/keywords/client.h
+++ b/tests/ami_test/keywords/client.h
@@ -30,14 +30,12 @@ public:
   inout_bool_excep (
     IDL::traits< ::Messaging::ExceptionHolder>::ref_type) override;
 
-
   void
   _cxx_uint32_t (int16_t ami_return_val) override;
 
   void
-  _cxx_uint32_t_excep (
+  uint32_t_excep (
     IDL::traits< ::Messaging::ExceptionHolder>::ref_type) override;
-
 
   void
   inout_int16_t (::Test::_cxx_int16_t ami_return_val,
@@ -77,7 +75,6 @@ public:
   void
   set_attr_bool_excep (
     IDL::traits< ::Messaging::ExceptionHolder>::ref_type) override;
-
 
   void
   get_attr_int16_t (
@@ -167,6 +164,32 @@ public:
   void
   shutdown_excep (
     IDL::traits< ::Messaging::ExceptionHolder>::ref_type) override;
+
+  void
+  _cxx_class () override;
+
+  void
+  class_excep (IDL::traits< ::Messaging::ExceptionHolder>::ref_type excep_holder) override;
+
+  void
+  _cxx_void (
+      const std::string& _cxx_virtual,
+      const std::string& interface) override;
+
+  void
+  void_excep (IDL::traits< ::Messaging::ExceptionHolder>::ref_type excep_holder) override;
+
+  void
+  get_private (::Test::_cxx_bool ami_return_val) override;
+
+  void
+  get_private_excep (IDL::traits< ::Messaging::ExceptionHolder>::ref_type excep_holder) override;
+
+  void
+  set_private () override;
+
+  void
+  set_private_excep (IDL::traits< ::Messaging::ExceptionHolder>::ref_type excep_holder) override;
 
 private:
   Handler (const Handler&) = delete;

--- a/tests/ami_test/keywords/test.idl
+++ b/tests/ami_test/keywords/test.idl
@@ -422,6 +422,10 @@ module Test
     long uintptr_t;
   };
 
+  exception protected
+  {
+  };
+
   /// An interface for testing IDL primitive types
   interface Hello
   {
@@ -444,6 +448,9 @@ module Test
       */
     int16_t inout_int16_t (in int16_t v_in, out int16_t v_out, inout int16_t v_inout);
 
+    void class ();
+
+    void _void (inout string virtual, inout string _interface);
 
     struct shortStruct
     {
@@ -457,6 +464,7 @@ module Test
     attribute cpplib_keyword_struct attr_cpplib_keyword_struct;
     attribute int_keyword_struct attr_int_keyword_struct;
     attribute cpp_keyword_struct attr_cpp_keyword_struct;
+    attribute bool _private setraises (protected);
 
     /// Test a regular oneway method, should appear in the
     /// ami stub

--- a/tests/ami_test/keywords/test_i.cpp
+++ b/tests/ami_test/keywords/test_i.cpp
@@ -11,7 +11,7 @@
 #include "testlib/taox11_testlog.h"
 
 Hello::Hello(IDL::traits<CORBA::ORB>::ref_type orb, int& result) :
-  orb_(orb), result_(result)
+  orb_(std::move(orb)), result_(result)
 {
 }
 
@@ -147,6 +147,24 @@ Hello::attr_cpp_keyword_struct (const ::Test::cpp_keyword_struct& _v)
 void Hello::bar ()
 {
   this->bar_called_ = true;
+}
+
+void Hello::_cxx_class ()
+{
+}
+
+void Hello::_cxx_void (std::string&, std::string&)
+{
+}
+
+::Test::_cxx_bool Hello::_cxx_private ()
+{
+  return _cxx_private_;
+}
+
+void Hello::_cxx_private (::Test::_cxx_bool _v)
+{
+  _cxx_private_ = _v;
 }
 
 // End

--- a/tests/ami_test/keywords/test_i.h
+++ b/tests/ami_test/keywords/test_i.h
@@ -54,6 +54,15 @@ public:
   void shutdown() override;
 
   void bar () override;
+
+  void _cxx_class () override;
+
+  void _cxx_void (std::string& _cxx_virtual, std::string& interface) override;
+
+  ::Test::_cxx_bool _cxx_private () override;
+
+  void _cxx_private (::Test::_cxx_bool _v) override;
+
 private:
   /// Use an ORB reference to convert strings to objects and shutdown
   /// the application.
@@ -61,14 +70,15 @@ private:
   int &result_;
 
   // Keep track of the attributes.
-  Test::_cxx_int32_t      int32_t_;      // short
-  Test::_cxx_bool         bool_;         // enum
-  Test::_cxx_int16_t      int16_t_;      // enum
-  Test::_cxx_int_least8_t int_least8_t_; // enum
+  Test::_cxx_int32_t      int32_t_{};      // short
+  Test::_cxx_bool         bool_{};         // enum
+  Test::_cxx_int16_t      int16_t_{};      // enum
+  Test::_cxx_int_least8_t int_least8_t_{}; // enum
 
   Test::cpplib_keyword_struct cpplib_keyword_struct_;
   Test::int_keyword_struct    int_keyword_struct_;
   Test::cpp_keyword_struct    cpp_keyword_struct_;
+  Test::_cxx_bool _cxx_private_ {};
 
   bool bar_called_ { false };
 


### PR DESCRIPTION
…keyword escaping rules, not the other way around

    * ridlbe/c++11/templates/cli/hdr/ami/attribute.erb:
    * ridlbe/c++11/templates/cli/hdr/ami/attribute_amic.erb:
    * ridlbe/c++11/templates/cli/hdr/ami/interface_amic_object_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/ami/operation.erb:
    * ridlbe/c++11/templates/cli/hdr/ami/operation_amic.erb:
    * ridlbe/c++11/templates/cli/prx/ami/attribute.erb:
    * ridlbe/c++11/templates/cli/prx/ami/operation.erb:
    * ridlbe/c++11/templates/cli/src/ami/attribute.erb:
    * ridlbe/c++11/templates/cli/src/ami/attribute_amic.erb:
    * ridlbe/c++11/templates/cli/src/ami/operation.erb:
    * ridlbe/c++11/templates/cli/src/ami/operation_amic.erb:
    * ridlbe/c++11/templates/srv/hdr/ami/attribute.erb:
    * ridlbe/c++11/templates/srv/hdr/ami/operation.erb:
    * ridlbe/c++11/templates/srv/src/ami/attribute.erb:
    * ridlbe/c++11/templates/srv/src/ami/exceptionholder_traits.erb:
    * ridlbe/c++11/templates/srv/src/ami/operation.erb:
    * ridlbe/c++11/visitors/mixins/ami_names.rb:
    * tests/ami_test/ami_naming/client.cpp:
    * tests/ami_test/keywords/client.cpp:
    * tests/ami_test/keywords/client.h:
    * tests/ami_test/keywords/test.idl:
    * tests/ami_test/keywords/test_i.cpp:
    * tests/ami_test/keywords/test_i.h: