### PR TITLE
Add missing override to the _default_POA operation as it is part of t…

### DIFF
--- a/ridlbe/c++11/templates/srv/hdr/tie/interface_pre.erb
+++ b/ridlbe/c++11/templates/srv/hdr/tie/interface_pre.erb
@@ -12,4 +12,4 @@ namespace POA
     virtual ~<%= tie_cxxname %> () = default;
     std::shared_ptr<T> _tied_object () { return tied_object_; };
     void _tied_object (std::shared_ptr<T> t) { tied_object_ = std::move(t); };
-    IDL::traits<TAOX11_NAMESPACE::PortableServer::POA>::ref_type _default_POA () { if (poa_) return poa_; else return TAOX11_NAMESPACE::PortableServer::Servant::_default_POA(); }
+    IDL::traits<TAOX11_NAMESPACE::PortableServer::POA>::ref_type _default_POA () override { if (poa_) return poa_; else return TAOX11_NAMESPACE::PortableServer::Servant::_default_POA(); }


### PR DESCRIPTION
…he TIE template

    * ridlbe/c++11/templates/srv/hdr/tie/interface_pre.erb: