### PR TITLE
Use a default constructor and make assignment/copy constructor delete…

### DIFF
--- a/ridlbe/c++11/templates/srv/hdr/valuetype_pre.erb
+++ b/ridlbe/c++11/templates/srv/hdr/valuetype_pre.erb
@@ -4,24 +4,31 @@ namespace POA
 {
   class <%= skel_export_macro %><%= skel_cxxname %>
     : public virtual <%= concrete_interface.scoped_skel_cxxtype %>
-    , public virtual TAOX11_CORBA::valuetype_traits< <%= scoped_cxxname%>>::base_type
+    , public virtual TAOX11_CORBA::valuetype_traits<<%= scoped_cxxname%>>::base_type
   {
   public:
     /// @name Member types
     //@{
-    typedef TAOX11_CORBA::servant_traits< <%= skel_cxxname %>>    _traits_type;
-    typedef TAOX11_CORBA::servant_reference< <%= skel_cxxname %>> _ref_type;
+    typedef TAOX11_CORBA::servant_traits<<%= skel_cxxname %>>    _traits_type;
+    typedef TAOX11_CORBA::servant_reference<<%= skel_cxxname %>> _ref_type;
     //@}
 
   protected:
     typedef std::shared_ptr<<%= skel_cxxname %>> _shared_ptr_type;
-    /// Constructor
-    <%= skel_cxxname %> ();
-    /// Destructor
+    <%= skel_cxxname %> () = default;
     virtual ~<%= skel_cxxname %> () = default;
 
     template <typename T> friend class TAOX11_CORBA::servant_reference;
 
     TAOX11_NAMESPACE::PortableServer::Servant::_shared_ptr_type _lock_shared ();
+
+  private:
+    /** @name Illegal to be called. Deleted explicitly to let the compiler detect any violation */
+    //@{
+    <%= skel_cxxname %> (const <%= skel_cxxname %>&) = delete;
+    <%= skel_cxxname %> (<%= skel_cxxname %>&&) = delete;
+    <%= skel_cxxname %>& operator= (const <%= skel_cxxname %>&) = delete;
+    <%= skel_cxxname %>& operator= (<%= skel_cxxname %>&&) = delete;
+    //@}
   };
 } // namespace POA

--- a/ridlbe/c++11/templates/srv/src/valuetype_pre.erb
+++ b/ridlbe/c++11/templates/srv/src/valuetype_pre.erb
@@ -2,12 +2,6 @@
 // generated from <%= ridl_template_path %>
 namespace POA
 {
-    <%= skel_cxxname %>::<%= skel_cxxname %> ()
-    : <%= concrete_interface.scoped_skel_cxxtype %> ()
-    , TAOX11_CORBA::valuetype_traits< <%= scoped_cxxname%>>::base_type ()
-    {
-    }
-
     TAOX11_NAMESPACE::PortableServer::Servant::_shared_ptr_type
     <%= skel_cxxname %>::_lock_shared ()
     {


### PR DESCRIPTION
…d for valuetype supports

    * ridlbe/c++11/templates/srv/hdr/valuetype_pre.erb:
    * ridlbe/c++11/templates/srv/src/valuetype_pre.erb: