### PR TITLE
Make use of C++11 using instead of typedef in the generated code

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_fwd.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_fwd.erb
@@ -4,8 +4,8 @@
 #if !defined (_INTF_AMI_<%= _intf_fwd_incl_guard_ %>_AMIC_FWD_)
 #define _INTF_AMI_<%= _intf_fwd_incl_guard_ %>_AMIC_FWD_
 class <%= amic_cxxname %>;
-typedef <%= amic_cxxname %> <%= amic_cxxname %>_idl_t; // IDL traits typename
+using <%= amic_cxxname %>_idl_t = <%= amic_cxxname %>; // IDL traits typename
 class <%= proxy_cxxname %>;
-typedef <%= proxy_cxxname %>* <%= proxy_cxxname %>_ptr;
+using <%= proxy_cxxname %>_ptr = <%= proxy_cxxname %> *;
 #endif // !_INTF_AMI<%= _intf_fwd_incl_guard_ %>_AMIC_FWD_
 %#

--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_fwd.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_fwd.erb
@@ -6,6 +6,6 @@
 class <%= amic_cxxname %>;
 using <%= amic_cxxname %>_idl_t = <%= amic_cxxname %>; // IDL traits typename
 class <%= proxy_cxxname %>;
-using <%= proxy_cxxname %>_ptr = <%= proxy_cxxname %> *;
+using <%= proxy_cxxname %>_ptr = <%= proxy_cxxname %>*;
 #endif // !_INTF_AMI<%= _intf_fwd_incl_guard_ %>_AMIC_FWD_
 %#

--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_object_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_object_traits.erb
@@ -35,13 +35,13 @@ namespace TAOX11_NAMESPACE
       public IDL::common_byval_traits <CORBA::object_reference < <%= amic_scoped_cxxtype %>>>,
       public CORBA::object_traits < <%= amic_scoped_cxxtype %>>
     {
-      typedef <%= handler_scoped_skel_cxxname %> replyhandler_base_type;
-      typedef TAOX11_CORBA::servant_traits<<%= handler_scoped_skel_cxxname %>> replyhandler_servant_traits;
-      typedef TAOX11_CORBA::servant_reference<<%=handler_scoped_skel_cxxname%>> replyhandler_servant_ref_type;
-      typedef TAOX11_CORBA::weak_servant_reference<<%=handler_scoped_skel_cxxname%>> replyhandler_weak_servant_ref_type;
-      typedef IDL::traits<<%= handler_scoped_cxxname %>> replyhandler_traits;
-      typedef replyhandler_traits::ref_type replyhandler_ref_type;
-      typedef replyhandler_traits::weak_ref_type replyhandler_weak_ref_type;
+      using replyhandler_base_type = <%= handler_scoped_skel_cxxname %>;
+      using replyhandler_servant_traits = TAOX11_CORBA::servant_traits<<%= handler_scoped_skel_cxxname %>>;
+      using replyhandler_servant_ref_type = TAOX11_CORBA::servant_reference<<%=handler_scoped_skel_cxxname%>>;
+      using replyhandler_weak_servant_ref_type = TAOX11_CORBA::weak_servant_reference<<%=handler_scoped_skel_cxxname%>>;
+      using replyhandler_traits = IDL::traits<<%= handler_scoped_cxxname %>>;
+      using replyhandler_ref_type = replyhandler_traits::ref_type;
+      using replyhandler_weak_ref_type = replyhandler_traits::weak_ref_type ;
 
       template <typename OStrm_, typename Formatter = IDL::formatter< <%= amic_scoped_cxxtype %>, OStrm_>>
       static inline OStrm_& write_on(

--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_post.erb
@@ -4,7 +4,7 @@
 %#
 
 protected:
-  typedef std::shared_ptr<<%= cxxname %>> _shared_ptr_type;
+  using _shared_ptr_type = std::shared_ptr<<%= cxxname %>>;
 
   template <typename _Tp1, typename, typename ...Args>
   friend TAOX11_CORBA::object_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);

--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_pre.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_pre.erb
@@ -19,6 +19,6 @@ public:
 
   /// @name Member types
   //@{
-  typedef TAOX11_NAMESPACE::CORBA::amic_traits<<%= cxxname %>> _traits_type;
-  typedef TAOX11_NAMESPACE::CORBA::amic_traits<<%= cxxname %>>::ref_type _ref_type;
+  using _traits_type = TAOX11_NAMESPACE::CORBA::amic_traits<<%= cxxname %>>;
+  using _ref_type = TAOX11_NAMESPACE::CORBA::amic_traits<<%= cxxname %>>::ref_type;
   //@}

--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_traits.erb
@@ -19,13 +19,13 @@ namespace IDL
       OStrm_& os,
       TAOX11_CORBA::amic_traits < <%= scoped_cxxtype %>>::__Writer<Fmt> w)
   {
-    typedef TAOX11_CORBA::amic_traits < <%= scoped_cxxtype %>>::__Writer<Fmt> writer_t;
-    typedef typename std::conditional<
-                        std::is_same<
-                          typename writer_t::formatter_t,
-                          std::false_type>::value,
-                        IDL::formatter< <%= amic_scoped_cxxtype %>, OStrm_>,
-                        typename writer_t::formatter_t>::type formatter_t;
+    using writer_t    = TAOX11_CORBA::amic_traits < <%= scoped_cxxtype %>>::__Writer<Fmt>;
+    using formatter_t = typename std::conditional<
+                          std::is_same<
+                            typename writer_t::formatter_t,
+                            std::false_type>::value,
+                          IDL::formatter< <%= amic_scoped_cxxtype %>, OStrm_>,
+                          typename writer_t::formatter_t>::type;
     return TAOX11_CORBA::amic_traits < <%= scoped_cxxtype %>>::write_on (
         os, w.val_,
         formatter_t ());

--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_traits.erb
@@ -19,7 +19,7 @@ namespace IDL
       OStrm_& os,
       TAOX11_CORBA::amic_traits < <%= scoped_cxxtype %>>::__Writer<Fmt> w)
   {
-    using writer_t    = TAOX11_CORBA::amic_traits < <%= scoped_cxxtype %>>::__Writer<Fmt>;
+    using writer_t = TAOX11_CORBA::amic_traits < <%= scoped_cxxtype %>>::__Writer<Fmt>;
     using formatter_t = typename std::conditional<
                           std::is_same<
                             typename writer_t::formatter_t,

--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_fwd.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_fwd.erb
@@ -6,7 +6,7 @@
 class <%= cxxname %>;
 % if is_remote? && !is_abstract?
 class <%= proxy_cxxname %>;
-typedef <%= proxy_cxxname %>* <%= proxy_cxxname %>_ptr;
+using <%= proxy_cxxname %>_ptr = <%= proxy_cxxname %>*;
 %   if generate_ami_support?
 namespace POA
 {

--- a/ridlbe/c++11/templates/cli/hdr/array_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/array_idl_traits.erb
@@ -11,10 +11,10 @@ struct traits < <%= scoped_cxxtype %>>
   : IDL::common_traits< <%= scoped_cxxtype %>>
 {
   /// IDL::traits<> for the element of the array
-  typedef IDL::traits< <%= scoped_element_traits_cxx_typename %>> element_traits;
+  using element_traits = IDL::traits< <%= scoped_element_traits_cxx_typename %>>;
   /// std::integral_constant type of value_type uint32_t
   /// indicating the number of dimensions of the array
-  typedef std::integral_constant<uint32_t, <%= cxxdim_sizes.size %>> dimensions;
+  using dimensions = std::integral_constant<uint32_t, <%= cxxdim_sizes.size %>>;
 
   template <typename OStrm_,
             typename Formatter = formatter< <%= scoped_cxxtype %>, OStrm_>
@@ -35,13 +35,13 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  typedef IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> writer_t;
-  typedef typename std::conditional<
-                      std::is_same<
-                        typename writer_t::formatter_t,
-                        std::false_type>::value,
-                      formatter< <%= scoped_cxxtype %>, OStrm_>,
-                      typename writer_t::formatter_t>::type formatter_t;
+  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using formatter_t = typename std::conditional<
+                        std::is_same<
+                          typename writer_t::formatter_t,
+                          std::false_type>::value,
+                        formatter< <%= scoped_cxxtype %>, OStrm_>,
+                        typename writer_t::formatter_t>::type;
   return IDL::traits< <%= scoped_cxxtype %>>::write_on (
       os, w.val_,
       formatter_t ());

--- a/ridlbe/c++11/templates/cli/hdr/array_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/array_idl_traits.erb
@@ -35,7 +35,7 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using writer_t = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
   using formatter_t = typename std::conditional<
                         std::is_same<
                           typename writer_t::formatter_t,

--- a/ridlbe/c++11/templates/cli/hdr/enum_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/enum_idl_traits.erb
@@ -38,13 +38,13 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  typedef IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> writer_t;
-  typedef typename std::conditional<
-                      std::is_same<
-                        typename writer_t::formatter_t,
-                        std::false_type>::value,
-                      formatter< <%= scoped_cxxtype %>, OStrm_>,
-                      typename writer_t::formatter_t>::type formatter_t;
+  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using formatter_t = typename std::conditional<
+                        std::is_same<
+                          typename writer_t::formatter_t,
+                          std::false_type>::value,
+                        formatter< <%= scoped_cxxtype %>, OStrm_>,
+                        typename writer_t::formatter_t>::type;
   return IDL::traits< <%= scoped_cxxtype %>>::write_on (
       os, w.val_,
       formatter_t ());

--- a/ridlbe/c++11/templates/cli/hdr/enum_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/enum_idl_traits.erb
@@ -38,7 +38,7 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using writer_t = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
   using formatter_t = typename std::conditional<
                         std::is_same<
                           typename writer_t::formatter_t,

--- a/ridlbe/c++11/templates/cli/hdr/fixed_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/fixed_idl_traits.erb
@@ -10,8 +10,8 @@ template<>
 struct traits < <%= scoped_cxxtype %>>
   : IDL::common_traits< <%= scoped_cxxtype %>>
 {
-  typedef std::integral_constant< uint16_t, <%= digits %>> digits;
-  typedef std::integral_constant< uint16_t, <%= scale %>> scale;
+  using digits = std::integral_constant< uint16_t, <%= digits %>>;
+  using scale = std::integral_constant< uint16_t, <%= scale %>>;
 
   template <typename OStrm_, typename Formatter = formatter<value_type, OStrm_>>
   static inline OStrm_& write_on(
@@ -43,13 +43,13 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  typedef IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> writer_t;
-  typedef typename std::conditional<
-                      std::is_same<
-                        typename writer_t::formatter_t,
-                        std::false_type>::value,
-                      formatter< <%= scoped_cxxtype %>, OStrm_>,
-                      typename writer_t::formatter_t>::type formatter_t;
+  using writer_t = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using formatter_t = typename std::conditional<
+                        std::is_same<
+                          typename writer_t::formatter_t,
+                          std::false_type>::value,
+                        formatter< <%= scoped_cxxtype %>, OStrm_>,
+                        typename writer_t::formatter_t>::type;
   return IDL::traits< <%= scoped_cxxtype %>>::write_on (
       os, w.val_,
       formatter_t ());

--- a/ridlbe/c++11/templates/cli/hdr/interface_fwd.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_fwd.erb
@@ -6,7 +6,7 @@
 class <%= cxxname %>;
 % if is_remote? && !is_abstract?
 class <%= proxy_cxxname %>;
-typedef <%= proxy_cxxname %>* <%= proxy_cxxname %>_ptr;
+using <%= proxy_cxxname %>_ptr = <%= proxy_cxxname %>*;
 % end
 #endif // !_INTF_<%= _intf_fwd_incl_guard_ %>_FWD_
 %#

--- a/ridlbe/c++11/templates/cli/hdr/interface_idl_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_idl_traits_def.erb
@@ -23,13 +23,13 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  typedef IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> writer_t;
-  typedef typename std::conditional<
-                      std::is_same<
-                        typename writer_t::formatter_t,
-                        std::false_type>::value,
-                      formatter< <%= scoped_cxxtype %>, OStrm_>,
-                      typename writer_t::formatter_t>::type formatter_t;
+  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using formatter_t = typename std::conditional<
+                        std::is_same<
+                          typename writer_t::formatter_t,
+                          std::false_type>::value,
+                        formatter< <%= scoped_cxxtype %>, OStrm_>,
+                        typename writer_t::formatter_t>::type;
   return IDL::traits< <%= scoped_cxxtype %>>::write_on (
       os, w.val_,
       formatter_t ());

--- a/ridlbe/c++11/templates/cli/hdr/interface_idl_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_idl_traits_def.erb
@@ -23,7 +23,7 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using writer_t = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
   using formatter_t = typename std::conditional<
                         std::is_same<
                           typename writer_t::formatter_t,

--- a/ridlbe/c++11/templates/cli/hdr/interface_object_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_object_traits.erb
@@ -47,14 +47,14 @@ namespace TAOX11_NAMESPACE
     {
       /// std::false_type or std::true_type type indicating whether
       /// this interface is declared as local
-      typedef std::<%= is_local? %>_type is_local;
+      using is_local = std::<%= is_local? %>_type;
       /// std::false_type or std::true_type type indicating whether
       /// this interface is declared as abstract
-      typedef std::<%= is_abstract? %>_type is_abstract;
+      using is_abstract = std::<%= is_abstract? %>_type;
 % if is_local?
       /// Trait for the type from which a local implementation needs
       /// to be derived from
-      typedef <%= scoped_cxxtype %> base_type;
+      using base_type = <%= scoped_cxxtype %>;
 % end
 
       template <typename OStrm_, typename Formatter = formatter< <%= scoped_cxxtype %>, OStrm_>>

--- a/ridlbe/c++11/templates/cli/hdr/interface_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_post.erb
@@ -41,7 +41,7 @@ private:
   TAOX11_IDL::traits<TAOX11_CORBA::ValueBase>::ref_type _to_value () override;
 %   end
 protected:
-  typedef std::shared_ptr<<%= cxxname %>> _shared_ptr_type;
+  using _shared_ptr_type = std::shared_ptr<<%= cxxname %>>;
 
   template <typename _Tp1, typename, typename ...Args>
   friend TAOX11_CORBA::object_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);
@@ -71,7 +71,7 @@ private:
 %##### Local interface #####
 %#
 protected:
-  typedef std::shared_ptr<<%= cxxname %>> _shared_ptr_type;
+  using _shared_ptr_type = std::shared_ptr<<%= cxxname %>>;
 
 %# msvc14.{0|1|2} have a bug that when using a defaulted constructor here we get a crash in the portableserver library
 %# for the POA

--- a/ridlbe/c++11/templates/cli/hdr/interface_pre.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_pre.erb
@@ -21,9 +21,9 @@ public:
 % if is_abstract?
   /// @name Member types
   //@{
-  typedef <%= cxx_traits_type %>           _traits_type;
+  using _traits_type = <%= cxx_traits_type %>;
   /// Strong reference type
-  typedef <%= cxx_traits_type %>::ref_type _ref_type;
+  using _ref_type = <%= cxx_traits_type %>::ref_type;
   //@}
 
   static bool _abs_unmarshal (TAO_InputCDR&, _ref_type&);
@@ -32,9 +32,9 @@ public:
 
   /// @name Member types
   //@{
-  typedef <%= cxx_traits_type %>           _traits_type;
+  using _traits_type = <%= cxx_traits_type %>;
   /// Strong reference type
-  typedef <%= cxx_traits_type %>::ref_type _ref_type;
+  using _ref_type = <%= cxx_traits_type %>::ref_type;
   //@}
 %   unless is_remote? && !has_abstract_base?
 

--- a/ridlbe/c++11/templates/cli/hdr/sequence_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/sequence_idl_traits.erb
@@ -15,7 +15,7 @@ struct traits < <%= scoped_cxxtype %>>
 {
   /// std::false_type or std::true_type type indicating whether
   /// this sequence is declared as bounded
-  using is_bounded     = std::<%= is_bounded? %>_type;
+  using is_bounded = std::<%= is_bounded? %>_type;
   /// IDL::traits<> for the element of the sequence
   using element_traits = IDL::traits< <%= scoped_element_traits_cxx_typename %>>;
 

--- a/ridlbe/c++11/templates/cli/hdr/sequence_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/sequence_idl_traits.erb
@@ -15,9 +15,9 @@ struct traits < <%= scoped_cxxtype %>>
 {
   /// std::false_type or std::true_type type indicating whether
   /// this sequence is declared as bounded
-  typedef std::<%= is_bounded? %>_type is_bounded;
+  using is_bounded     = std::<%= is_bounded? %>_type;
   /// IDL::traits<> for the element of the sequence
-  typedef IDL::traits< <%= scoped_element_traits_cxx_typename %>> element_traits;
+  using element_traits = IDL::traits< <%= scoped_element_traits_cxx_typename %>>;
 
   template <typename OStrm_, typename Formatter = formatter<value_type, OStrm_>>
   static inline OStrm_& write_on(
@@ -36,13 +36,13 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  typedef IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> writer_t;
-  typedef typename std::conditional<
-                      std::is_same<
-                        typename writer_t::formatter_t,
-                        std::false_type>::value,
-                      formatter< <%= scoped_cxxtype %>, OStrm_>,
-                      typename writer_t::formatter_t>::type formatter_t;
+  using writer_t = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using formatter_t = typename std::conditional<
+                        std::is_same<
+                          typename writer_t::formatter_t,
+                          std::false_type>::value,
+                        formatter< <%= scoped_cxxtype %>, OStrm_>,
+                        typename writer_t::formatter_t>::type;
   return IDL::traits< <%= scoped_cxxtype %>>::write_on (
       os, w.val_,
       formatter_t ());

--- a/ridlbe/c++11/templates/cli/hdr/string_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/string_idl_traits.erb
@@ -13,9 +13,9 @@ struct traits < <%= scoped_cxxtype %>>
 {
   /// std::false_type or std::true_type type indicating whether
   /// this string is declared as bounded
-  typedef std::true_type is_bounded;
+  using is_bounded     = std::true_type ;
   /// IDL::traits<> for the element of the string
-  typedef IDL::traits<<% if is_wstring? %>wchar_t<% else %>char<% end %>> element_traits;
+  using element_traits = IDL::traits<<% if is_wstring? %>wchar_t<% else %>char<% end %>>;
 
   template <typename OStrm_, typename Formatter = formatter<value_type, OStrm_>>
   static inline OStrm_& write_on(
@@ -34,13 +34,13 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  typedef IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> writer_t;
-  typedef typename std::conditional<
-                      std::is_same<
-                        typename writer_t::formatter_t,
-                        std::false_type>::value,
-                      formatter< <%= scoped_cxxtype %>, OStrm_>,
-                      typename writer_t::formatter_t>::type formatter_t;
+  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using formatter_t = typename std::conditional<
+                        std::is_same<
+                          typename writer_t::formatter_t,
+                          std::false_type>::value,
+                        formatter< <%= scoped_cxxtype %>, OStrm_>,
+                        typename writer_t::formatter_t>::type;
   return IDL::traits< <%= scoped_cxxtype %>>::write_on (
       os, w.val_,
       formatter_t ());

--- a/ridlbe/c++11/templates/cli/hdr/string_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/string_idl_traits.erb
@@ -13,7 +13,7 @@ struct traits < <%= scoped_cxxtype %>>
 {
   /// std::false_type or std::true_type type indicating whether
   /// this string is declared as bounded
-  using is_bounded     = std::true_type ;
+  using is_bounded = std::true_type ;
   /// IDL::traits<> for the element of the string
   using element_traits = IDL::traits<<% if is_wstring? %>wchar_t<% else %>char<% end %>>;
 
@@ -34,7 +34,7 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using writer_t = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
   using formatter_t = typename std::conditional<
                         std::is_same<
                           typename writer_t::formatter_t,

--- a/ridlbe/c++11/templates/cli/hdr/struct_idl_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/struct_idl_traits_def.erb
@@ -47,13 +47,13 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  typedef IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> writer_t;
-  typedef typename std::conditional<
-                      std::is_same<
-                        typename writer_t::formatter_t,
-                        std::false_type>::value,
-                      formatter< <%= scoped_cxxtype %>, OStrm_>,
-                      typename writer_t::formatter_t>::type formatter_t;
+  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using formatter_t = typename std::conditional<
+                        std::is_same<
+                          typename writer_t::formatter_t,
+                          std::false_type>::value,
+                        formatter< <%= scoped_cxxtype %>, OStrm_>,
+                        typename writer_t::formatter_t>::type;
   return IDL::traits< <%= scoped_cxxtype %>>::write_on (
       os, w.val_,
       formatter_t ());

--- a/ridlbe/c++11/templates/cli/hdr/struct_idl_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/struct_idl_traits_def.erb
@@ -47,7 +47,7 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using writer_t = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
   using formatter_t = typename std::conditional<
                         std::is_same<
                           typename writer_t::formatter_t,

--- a/ridlbe/c++11/templates/cli/hdr/typedef.erb
+++ b/ridlbe/c++11/templates/cli/hdr/typedef.erb
@@ -1,5 +1,5 @@
 
 // generated from <%= ridl_template_path %>
 /// @copydoc <%= doc_scoped_name %>
-typedef <%= cxxtype %> <%= cxxname %>;
+using <%= cxxname %> = <%= cxxtype %>;
 % visit_template('typecode') if generate_typecode_support? && !is_native?

--- a/ridlbe/c++11/templates/cli/hdr/union_idl_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_idl_traits_def.erb
@@ -67,7 +67,7 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using writer_t = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
   using formatter_t = typename std::conditional<
                         std::is_same<
                           typename writer_t::formatter_t,

--- a/ridlbe/c++11/templates/cli/hdr/union_idl_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_idl_traits_def.erb
@@ -67,13 +67,13 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  typedef IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> writer_t;
-  typedef typename std::conditional<
-                      std::is_same<
-                        typename writer_t::formatter_t,
-                        std::false_type>::value,
-                      formatter< <%= scoped_cxxtype %>, OStrm_>,
-                      typename writer_t::formatter_t>::type formatter_t;
+  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using formatter_t = typename std::conditional<
+                        std::is_same<
+                          typename writer_t::formatter_t,
+                          std::false_type>::value,
+                        formatter< <%= scoped_cxxtype %>, OStrm_>,
+                        typename writer_t::formatter_t>::type;
   return IDL::traits< <%= scoped_cxxtype %>>::write_on (
       os, w.val_,
       formatter_t ());

--- a/ridlbe/c++11/templates/cli/hdr/valuebox_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuebox_def.erb
@@ -6,8 +6,8 @@ class <%= stub_export_macro %><%= cxxname %> final
 public:
   /// @name Member types
   //@{
-  typedef TAOX11_CORBA::valuetype_traits< <%= cxxname %>>     _traits_type;
-  typedef TAOX11_CORBA::valuetype_reference< <%= cxxname %>>  _ref_type;
+  using _traits_type = TAOX11_CORBA::valuetype_traits< <%= cxxname %>>;
+  using _ref_type = TAOX11_CORBA::valuetype_reference< <%= cxxname %>>;
   //@}
 
   void _value (<%= boxed_cxx_in_type %> v) { this->value_ = v; }

--- a/ridlbe/c++11/templates/cli/hdr/valuebox_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuebox_idl_traits.erb
@@ -19,7 +19,7 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using writer_t = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
   using formatter_t = typename std::conditional<
                         std::is_same<
                           typename writer_t::formatter_t,

--- a/ridlbe/c++11/templates/cli/hdr/valuebox_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuebox_idl_traits.erb
@@ -3,7 +3,7 @@
 template <typename OStrm_>
 struct formatter< <%= scoped_cxxtype %>, OStrm_>
 {
-  typedef typename IDL::traits< <%= scoped_cxxtype %>>::boxed_traits boxed_traits;
+  using boxed_traits = typename IDL::traits< <%= scoped_cxxtype %>>::boxed_traits;
 
   inline OStrm_& operator ()(
       OStrm_& os_,
@@ -19,13 +19,13 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  typedef IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> writer_t;
-  typedef typename std::conditional<
-                      std::is_same<
-                        typename writer_t::formatter_t,
-                        std::false_type>::value,
-                      formatter< <%= scoped_cxxtype %>, OStrm_>,
-                      typename writer_t::formatter_t>::type formatter_t;
+  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using formatter_t = typename std::conditional<
+                        std::is_same<
+                          typename writer_t::formatter_t,
+                          std::false_type>::value,
+                        formatter< <%= scoped_cxxtype %>, OStrm_>,
+                        typename writer_t::formatter_t>::type;
   return IDL::traits< <%= scoped_cxxtype %>>::write_on (
       os, w.val_,
       formatter_t ());

--- a/ridlbe/c++11/templates/cli/hdr/valuebox_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuebox_traits.erb
@@ -11,7 +11,7 @@ namespace TAOX11_NAMESPACE
     struct <%= stub_export_macro %>valuetype_traits< <%= scoped_cxxtype %>>
     {
       /// Strong reference type
-      using ref_type      = valuetype_reference< <%= scoped_cxxtype %>>;
+      using ref_type = valuetype_reference< <%= scoped_cxxtype %>>;
       /// Weak reference type
       using weak_ref_type = weak_valuetype_reference< <%= scoped_cxxtype %>>;
 

--- a/ridlbe/c++11/templates/cli/hdr/valuebox_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuebox_traits.erb
@@ -11,9 +11,9 @@ namespace TAOX11_NAMESPACE
     struct <%= stub_export_macro %>valuetype_traits< <%= scoped_cxxtype %>>
     {
       /// Strong reference type
-      typedef valuetype_reference< <%= scoped_cxxtype %>> ref_type;
+      using ref_type      = valuetype_reference< <%= scoped_cxxtype %>>;
       /// Weak reference type
-      typedef weak_valuetype_reference< <%= scoped_cxxtype %>> weak_ref_type;
+      using weak_ref_type = weak_valuetype_reference< <%= scoped_cxxtype %>>;
 
       static ref_type narrow (valuetype_reference<ValueBase>);
     };
@@ -27,7 +27,7 @@ namespace TAOX11_NAMESPACE
         public CORBA::valuetype_traits < <%= scoped_cxxtype %>>
     {
       /// IDL::traits for the boxed type of the valuebox
-      typedef IDL::traits< <%= scoped_boxed_traits_cxx_typename %>>  boxed_traits;
+      using boxed_traits = IDL::traits< <%= scoped_boxed_traits_cxx_typename %>>;
 
       template <typename OStrm_, typename Formatter = formatter< <%= scoped_cxxtype %>, OStrm_>>
       static inline OStrm_& write_on(

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_idl_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_idl_traits_def.erb
@@ -36,7 +36,7 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using writer_t = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
   using formatter_t = typename std::conditional<
                         std::is_same<
                           typename writer_t::formatter_t,

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_idl_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_idl_traits_def.erb
@@ -36,13 +36,13 @@ inline OStrm_& operator <<(
     OStrm_& os,
     IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
-  typedef IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt> writer_t;
-  typedef typename std::conditional<
-                      std::is_same<
-                        typename writer_t::formatter_t,
-                        std::false_type>::value,
-                      formatter< <%= scoped_cxxtype %>, OStrm_>,
-                      typename writer_t::formatter_t>::type formatter_t;
+  using writer_t    = IDL::traits< <%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using formatter_t = typename std::conditional<
+                        std::is_same<
+                          typename writer_t::formatter_t,
+                          std::false_type>::value,
+                        formatter< <%= scoped_cxxtype %>, OStrm_>,
+                        typename writer_t::formatter_t>::type;
   return IDL::traits< <%= scoped_cxxtype %>>::write_on (
       os, w.val_,
       formatter_t ());

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_init.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_init.erb
@@ -4,8 +4,8 @@ class <%= stub_export_macro %><%= factory_cxxname %>
   : public TAOX11_CORBA::ValueFactoryBase
 {
 public:
-  typedef <%= factory_traits_type %>           _traits_type;
-  typedef <%= factory_traits_type %>::ref_type _ref_type;
+  using _traits_type = <%= factory_traits_type %>;
+  using _ref_type = <%= factory_traits_type %>::ref_type;
 
   template <typename T> friend struct TAOX11_CORBA::object_traits;
 % if is_concrete?

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_pre.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_pre.erb
@@ -17,14 +17,14 @@ class <%= stub_export_macro %><%= cxxname %>
 public:
   /// @name Member types
   //@{
-  typedef <%= cxx_traits_type %>               _traits_type;
+  using _traits_type = <%= cxx_traits_type %>;
   /// Strong reference type
-  typedef <%= cxx_traits_type %>::ref_type     _ref_type;
+  using _ref_type = <%= cxx_traits_type %>::ref_type;
 % if has_factory?
-  typedef <%= cxx_traits_type %>::factory_type _factory_type;
+  using _factory_type = <%= cxx_traits_type %>::factory_type;
 % end
 % unless is_abstract?
-  typedef <%= cxx_traits_type %>::obv_type     _obv_type;
+  using _obv_type = <%= cxx_traits_type %>::obv_type;
 % end
   //@}
 
@@ -45,7 +45,7 @@ protected:
   friend class <%= factory_cxxname %>;
 
 % end
-  typedef std::shared_ptr<<%= cxxname %>> _shared_ptr_type;
+  using _shared_ptr_type = std::shared_ptr<<%= cxxname %>>;
 
   static const std::string __<%= cxxname.downcase %>_repository_id;
 

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_traits.erb
@@ -32,32 +32,22 @@ namespace TAOX11_NAMESPACE
     template <>
     struct <%= stub_export_macro %>valuetype_traits< <%= scoped_cxxtype %>>
     {
-      using base_type =
-        <%= scoped_cxxtype %>;
+      using base_type = <%= scoped_cxxtype %>;
       /// Strong reference type
-      using ref_type =
-        valuetype_reference< <%= scoped_cxxtype %>>;
+      using ref_type = valuetype_reference< <%= scoped_cxxtype %>>;
       /// Weak reference type
-      using weak_ref_type =
-        weak_valuetype_reference< <%= scoped_cxxtype %>>;
+      using weak_ref_type = weak_valuetype_reference< <%= scoped_cxxtype %>>;
 % unless is_abstract?
-      using obv_type =
-        <%= scoped_obv_cxxtype %>;
+      using obv_type = <%= scoped_obv_cxxtype %>;
 % end
 % if has_factory?
-      using factory_type =
-        <%= scoped_factory_cxx_type %>;
-      using factory_ref_type =
-        <%= scoped_factory_traits_type %>::ref_type;
-      using weak_factory_ref_type =
-        <%= scoped_factory_traits_type %>::weak_ref_type;
+      using factory_type = <%= scoped_factory_cxx_type %>;
+      using factory_ref_type = <%= scoped_factory_traits_type %>::ref_type;
+      using weak_factory_ref_type = <%= scoped_factory_traits_type %>::weak_ref_type;
 % elsif !is_abstract?
-      using factory_type =
-        CORBA::ValueFactoryBase;
-      using factory_ref_type =
-        IDL::traits<CORBA::ValueFactoryBase>::ref_type;
-      using weak_factory_ref_type =
-        IDL::traits<CORBA::ValueFactoryBase>::weak_ref_type;
+      using factory_type = CORBA::ValueFactoryBase;
+      using factory_ref_type = IDL::traits<CORBA::ValueFactoryBase>::ref_type;
+      using weak_factory_ref_type = IDL::traits<CORBA::ValueFactoryBase>::weak_ref_type;
 % end
       template <typename _Tp1, typename = typename
           std::enable_if<std::is_convertible< <%= scoped_cxxtype %>*, _Tp1*>::value>::type>

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_traits.erb
@@ -21,8 +21,8 @@ namespace TAOX11_NAMESPACE
       public IDL::common_byval_traits <CORBA::object_reference < <%= scoped_factory_cxx_type %>>>,
       public CORBA::object_traits < <%= scoped_factory_cxx_type %>>
     {
-      typedef std::false_type is_abstract;
-      typedef std::true_type is_local;
+      using is_abstract = std::false_type ;
+      using is_local = std::true_type;
     };
   } // namespace IDL
 
@@ -32,32 +32,32 @@ namespace TAOX11_NAMESPACE
     template <>
     struct <%= stub_export_macro %>valuetype_traits< <%= scoped_cxxtype %>>
     {
-      typedef <%= scoped_cxxtype %>
-          base_type;
+      using base_type =
+        <%= scoped_cxxtype %>;
       /// Strong reference type
-      typedef valuetype_reference< <%= scoped_cxxtype %>>
-          ref_type;
+      using ref_type =
+        valuetype_reference< <%= scoped_cxxtype %>>;
       /// Weak reference type
-      typedef weak_valuetype_reference< <%= scoped_cxxtype %>>
-          weak_ref_type;
+      using weak_ref_type =
+        weak_valuetype_reference< <%= scoped_cxxtype %>>;
 % unless is_abstract?
-      typedef <%= scoped_obv_cxxtype %>
-          obv_type;
+      using obv_type =
+        <%= scoped_obv_cxxtype %>;
 % end
 % if has_factory?
-      typedef <%= scoped_factory_cxx_type %>
-          factory_type;
-      typedef <%= scoped_factory_traits_type %>::ref_type
-          factory_ref_type;
-      typedef <%= scoped_factory_traits_type %>::weak_ref_type
-          weak_factory_ref_type;
+      using factory_type =
+        <%= scoped_factory_cxx_type %>;
+      using factory_ref_type =
+        <%= scoped_factory_traits_type %>::ref_type;
+      using weak_factory_ref_type =
+        <%= scoped_factory_traits_type %>::weak_ref_type;
 % elsif !is_abstract?
-      typedef CORBA::ValueFactoryBase
-      factory_type;
-      typedef IDL::traits<CORBA::ValueFactoryBase>::ref_type
-      factory_ref_type;
-      typedef IDL::traits<CORBA::ValueFactoryBase>::weak_ref_type
-      weak_factory_ref_type;
+      using factory_type =
+        CORBA::ValueFactoryBase;
+      using factory_ref_type =
+        IDL::traits<CORBA::ValueFactoryBase>::ref_type;
+      using weak_factory_ref_type =
+        IDL::traits<CORBA::ValueFactoryBase>::weak_ref_type;
 % end
       template <typename _Tp1, typename = typename
           std::enable_if<std::is_convertible< <%= scoped_cxxtype %>*, _Tp1*>::value>::type>
@@ -75,8 +75,8 @@ namespace TAOX11_NAMESPACE
       : public IDL::common_byval_traits<CORBA::valuetype_reference< <%= scoped_cxxtype %>>>,
         public CORBA::valuetype_traits < <%= scoped_cxxtype %>>
     {
-      typedef std::<%= is_abstract? %>_type is_abstract;
-      typedef std::<%= is_truncatable? %>_type is_truncatable;
+      using is_abstract = std::<%= is_abstract? %>_type;
+      using is_truncatable = std::<%= is_truncatable? %>_type;
 
       template <typename OStrm_, typename Formatter = formatter< <%= scoped_cxxtype %>, OStrm_>>
       static inline OStrm_& write_on(

--- a/ridlbe/c++11/templates/cli/prx/interface_object_var.erb
+++ b/ridlbe/c++11/templates/cli/prx/interface_object_var.erb
@@ -5,14 +5,13 @@
 % unless is_abstract?
 
 class <%= proxy_cxxname %>;
-typedef <%= proxy_cxxname %> *<%= proxy_cxxname %>_ptr;
+using <%= proxy_cxxname %>_ptr =
+  <%= proxy_cxxname %> *;
 
-typedef
-  TAO_Objref_Var_T< <%= proxy_cxxname %>>
-    <%= proxy_cxxname %>_var;
+using <%= proxy_cxxname %>_var =
+  TAO_Objref_Var_T< <%= proxy_cxxname %>>;
 
-typedef
-  TAO_Objref_Out_T< <%= proxy_cxxname %>>
-    <%= proxy_cxxname %>_out;
+using <%= proxy_cxxname %>_out =
+  TAO_Objref_Out_T< <%= proxy_cxxname %>>;
 % end
 #endif // !_INTF_<%= _intf_traits_decl_incl_guard_ %>_VAR_OUT_CH_

--- a/ridlbe/c++11/templates/cli/prx/interface_object_var.erb
+++ b/ridlbe/c++11/templates/cli/prx/interface_object_var.erb
@@ -5,13 +5,8 @@
 % unless is_abstract?
 
 class <%= proxy_cxxname %>;
-using <%= proxy_cxxname %>_ptr =
-  <%= proxy_cxxname %> *;
-
-using <%= proxy_cxxname %>_var =
-  TAO_Objref_Var_T< <%= proxy_cxxname %>>;
-
-using <%= proxy_cxxname %>_out =
-  TAO_Objref_Out_T< <%= proxy_cxxname %>>;
+using <%= proxy_cxxname %>_ptr = <%= proxy_cxxname %>*;
+using <%= proxy_cxxname %>_var = TAO_Objref_Var_T< <%= proxy_cxxname %>>;
+using <%= proxy_cxxname %>_out = TAO_Objref_Out_T< <%= proxy_cxxname %>>;
 % end
 #endif // !_INTF_<%= _intf_traits_decl_incl_guard_ %>_VAR_OUT_CH_

--- a/ridlbe/c++11/templates/cli/prx/interface_pre.erb
+++ b/ridlbe/c++11/templates/cli/prx/interface_pre.erb
@@ -20,7 +20,7 @@ public:
   friend class TAO_TAO::Narrow_Utils<<%= proxy_cxxname %>>;
   friend struct TAOX11_CORBA::object_traits<<%= cxxname %>>;
 
-  using _ptr_type = <%= proxy_cxxname %> *;
+  using _ptr_type = <%= proxy_cxxname %>*;
   using _var_type = TAO_Objref_Var_T<<%= proxy_cxxname %>>;
   using _out_type = TAO_Objref_Out_T<<%= proxy_cxxname %>>;
 

--- a/ridlbe/c++11/templates/cli/prx/interface_pre.erb
+++ b/ridlbe/c++11/templates/cli/prx/interface_pre.erb
@@ -20,9 +20,9 @@ public:
   friend class TAO_TAO::Narrow_Utils<<%= proxy_cxxname %>>;
   friend struct TAOX11_CORBA::object_traits<<%= cxxname %>>;
 
-  typedef <%= proxy_cxxname %>* _ptr_type;
-  typedef TAO_Objref_Var_T<<%= proxy_cxxname %>> _var_type;
-  typedef TAO_Objref_Out_T<<%= proxy_cxxname %>> _out_type;
+  using _ptr_type = <%= proxy_cxxname %> *;
+  using _var_type = TAO_Objref_Var_T<<%= proxy_cxxname %>>;
+  using _out_type = TAO_Objref_Out_T<<%= proxy_cxxname %>>;
 
   static _ptr_type _duplicate (_ptr_type obj);
   static _ptr_type _narrow (TAO_CORBA::Object::_ptr_type obj);

--- a/ridlbe/c++11/templates/cli/src/interface_object_traits.erb
+++ b/ridlbe/c++11/templates/cli/src/interface_object_traits.erb
@@ -10,7 +10,7 @@ abstractbase_traits< <%= scoped_cxxtype %>>::narrow (
 
   if (abref)
   {
-    typedef <%= scoped_cxxtype %> ab_type_t;
+    using ab_type_t = <%= scoped_cxxtype %>;
     try {
       if (abref->_is_object ())
       {

--- a/ridlbe/c++11/templates/srv/hdr/interface_pre.erb
+++ b/ridlbe/c++11/templates/srv/hdr/interface_pre.erb
@@ -23,8 +23,8 @@ namespace POA
   public:
     /// @name Member types
     //@{
-    using _traits_type = TAOX11_CORBA::servant_traits< <%= skel_cxxname %>>;
-    using _ref_type = TAOX11_CORBA::servant_reference< <%= skel_cxxname %>>;
+    using _traits_type = TAOX11_CORBA::servant_traits<<%= skel_cxxname %>>;
+    using _ref_type = TAOX11_CORBA::servant_reference<<%= skel_cxxname %>>;
     //@}
 
   protected:

--- a/ridlbe/c++11/templates/srv/hdr/interface_pre.erb
+++ b/ridlbe/c++11/templates/srv/hdr/interface_pre.erb
@@ -2,7 +2,7 @@
 namespace POA
 {
   class <%= srvproxy_cxxname %>;
-  using <%= srvproxy_cxxname %>_ptr = <%= srvproxy_cxxname %> *;
+  using <%= srvproxy_cxxname %>_ptr = <%= srvproxy_cxxname %>*;
 
   class <%= skel_export_macro %><%= skel_cxxname %>
 % if is_derived?

--- a/ridlbe/c++11/templates/srv/hdr/interface_pre.erb
+++ b/ridlbe/c++11/templates/srv/hdr/interface_pre.erb
@@ -28,10 +28,7 @@ namespace POA
     //@}
 
   protected:
-    /// Constructor
     explicit <%= skel_cxxname %> (bool inherited = false);
-
-    /// Destructor
     virtual ~<%= skel_cxxname %> ();
 
     Servant_proxy_ptr get_proxy () const override;

--- a/ridlbe/c++11/templates/srv/hdr/interface_pre.erb
+++ b/ridlbe/c++11/templates/srv/hdr/interface_pre.erb
@@ -2,7 +2,7 @@
 namespace POA
 {
   class <%= srvproxy_cxxname %>;
-  typedef <%= srvproxy_cxxname %>* <%= srvproxy_cxxname %>_ptr;
+  using <%= srvproxy_cxxname %>_ptr = <%= srvproxy_cxxname %> *;
 
   class <%= skel_export_macro %><%= skel_cxxname %>
 % if is_derived?
@@ -23,8 +23,8 @@ namespace POA
   public:
     /// @name Member types
     //@{
-    typedef TAOX11_CORBA::servant_traits< <%= skel_cxxname %>>    _traits_type;
-    typedef TAOX11_CORBA::servant_reference< <%= skel_cxxname %>> _ref_type;
+    using _traits_type = TAOX11_CORBA::servant_traits< <%= skel_cxxname %>>;
+    using _ref_type = TAOX11_CORBA::servant_reference< <%= skel_cxxname %>>;
     //@}
 
   protected:

--- a/ridlbe/c++11/templates/srv/hdr/interface_servant_traits.erb
+++ b/ridlbe/c++11/templates/srv/hdr/interface_servant_traits.erb
@@ -5,11 +5,11 @@ struct <%= skel_export_macro %>servant_traits< <%= scoped_cxxtype %>>
 {
   /// Base trait type from which the servant implementations has to be derived
   /// from
-  typedef <%= scoped_skel_cxxtype %> base_type;
+  using base_type = <%= scoped_skel_cxxtype %>;
   /// Strong reference type
-  typedef TAOX11_CORBA::servant_reference< <%= scoped_skel_cxxtype %>> ref_type;
+  using ref_type = TAOX11_CORBA::servant_reference< <%= scoped_skel_cxxtype %>>;
   /// Weak reference type
-  typedef TAOX11_CORBA::weak_servant_reference< <%= scoped_skel_cxxtype %>> weak_ref_type;
+  using weak_ref_type = TAOX11_CORBA::weak_servant_reference< <%= scoped_skel_cxxtype %>>;
 %if generate_tie_support?
   /// TIE type
   template<class T> using tie_type = <%= scoped_tie_cxxtype %><T>;

--- a/ridlbe/c++11/templates/srv/hdr/valuetype_pre.erb
+++ b/ridlbe/c++11/templates/srv/hdr/valuetype_pre.erb
@@ -9,8 +9,8 @@ namespace POA
   public:
     /// @name Member types
     //@{
-    using _traits_type = TAOX11_CORBA::servant_traits< <%= skel_cxxname %>>;
-    using _ref_type = TAOX11_CORBA::servant_reference< <%= skel_cxxname %>>;
+    using _traits_type = TAOX11_CORBA::servant_traits<<%= skel_cxxname %>>;
+    using _ref_type = TAOX11_CORBA::servant_reference<<%= skel_cxxname %>>;
     //@}
 
   protected:

--- a/ridlbe/c++11/templates/srv/hdr/valuetype_pre.erb
+++ b/ridlbe/c++11/templates/srv/hdr/valuetype_pre.erb
@@ -9,12 +9,12 @@ namespace POA
   public:
     /// @name Member types
     //@{
-    typedef TAOX11_CORBA::servant_traits< <%= skel_cxxname %>>    _traits_type;
-    typedef TAOX11_CORBA::servant_reference< <%= skel_cxxname %>> _ref_type;
+    using _traits_type = TAOX11_CORBA::servant_traits< <%= skel_cxxname %>>;
+    using _ref_type = TAOX11_CORBA::servant_reference< <%= skel_cxxname %>>;
     //@}
 
   protected:
-    typedef std::shared_ptr<<%= skel_cxxname %>> _shared_ptr_type;
+    using _shared_ptr_type = std::shared_ptr<<%= skel_cxxname %>>;
     /// Constructor
     <%= skel_cxxname %> ();
     /// Destructor

--- a/ridlbe/c++11/templates/srv/prx/interface_pre.erb
+++ b/ridlbe/c++11/templates/srv/prx/interface_pre.erb
@@ -5,7 +5,7 @@ class <%= skel_export_macro %><%= srvproxy_cxxname %> final
 {
 public:
   using skel_type = <%= scoped_skel_cxxtype %>;
-  using skel_ptr = skel_type *;
+  using skel_ptr = skel_type*;
 
   explicit <%= srvproxy_cxxname %> (<%= srvproxy_cxxname %>::skel_ptr skel);
   virtual ~<%= srvproxy_cxxname %> () = default;

--- a/ridlbe/c++11/templates/srv/prx/interface_pre.erb
+++ b/ridlbe/c++11/templates/srv/prx/interface_pre.erb
@@ -4,8 +4,8 @@ class <%= skel_export_macro %><%= srvproxy_cxxname %> final
   : public TAOX11_NAMESPACE::Servant_proxy
 {
 public:
-  typedef <%= scoped_skel_cxxtype %> skel_type;
-  typedef skel_type *skel_ptr;
+  using skel_type = <%= scoped_skel_cxxtype %>;
+  using skel_ptr = skel_type *;
 
   explicit <%= srvproxy_cxxname %> (<%= srvproxy_cxxname %>::skel_ptr skel);
   virtual ~<%= srvproxy_cxxname %> () = default;

--- a/ridlbe/c++11/templates/srv/src/array_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/array_sarg_traits.erb
@@ -14,11 +14,10 @@ namespace PS
         Basic_SArg_Traits_T<
             <%= scoped_cxxtype %>,
 % if generate_any_support?
-            Any_Insert_Policy_Stream
+            Any_Insert_Policy_Stream>
 % else
-            Any_Insert_Policy_Noop
+            Any_Insert_Policy_Noop>
 % end
-            >
   {
   };
 } // namespace PS

--- a/ridlbe/c++11/templates/srv/src/enum_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/enum_sarg_traits.erb
@@ -12,11 +12,10 @@ namespace PS
         Basic_SArg_Traits_T<
             <%= scoped_cxxtype %>,
 % if generate_any_support?
-            Any_Insert_Policy_Stream
+            Any_Insert_Policy_Stream>
 % else
-            Any_Insert_Policy_Noop
+            Any_Insert_Policy_Noop>
 % end
-            >
   {
   };
 } // namespace PS

--- a/ridlbe/c++11/templates/srv/src/interface_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/interface_sarg_traits.erb
@@ -11,11 +11,10 @@ namespace PS
     : public Basic_SArg_Traits_T<
           <%= scoped_cxx_traits_type %>::ref_type,
 % if generate_any_support?
-          Any_Insert_Policy_Stream
+          Any_Insert_Policy_Stream>
 % else
-          Any_Insert_Policy_Noop
+          Any_Insert_Policy_Noop>
 % end
-          >
   {
   };
 } // namespace PS


### PR DESCRIPTION
    * ridlbe/c++11/templates/cli/hdr/ami/interface_amic_fwd.erb:
    * ridlbe/c++11/templates/cli/hdr/ami/interface_amic_object_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/ami/interface_amic_post.erb:
    * ridlbe/c++11/templates/cli/hdr/ami/interface_amic_pre.erb:
    * ridlbe/c++11/templates/cli/hdr/ami/interface_amic_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/ami/interface_fwd.erb:
    * ridlbe/c++11/templates/cli/hdr/array_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/enum_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/fixed_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/interface_fwd.erb:
    * ridlbe/c++11/templates/cli/hdr/interface_idl_traits_def.erb:
    * ridlbe/c++11/templates/cli/hdr/interface_object_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/interface_post.erb:
    * ridlbe/c++11/templates/cli/hdr/interface_pre.erb:
    * ridlbe/c++11/templates/cli/hdr/sequence_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/string_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/struct_idl_traits_def.erb:
    * ridlbe/c++11/templates/cli/hdr/typedef.erb:
    * ridlbe/c++11/templates/cli/hdr/union_idl_traits_def.erb:
    * ridlbe/c++11/templates/cli/hdr/valuebox_def.erb:
    * ridlbe/c++11/templates/cli/hdr/valuebox_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/valuebox_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_idl_traits_def.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_init.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_pre.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_traits.erb:
    * ridlbe/c++11/templates/cli/prx/interface_object_var.erb:
    * ridlbe/c++11/templates/cli/prx/interface_pre.erb:
    * ridlbe/c++11/templates/cli/src/interface_object_traits.erb:
    * ridlbe/c++11/templates/srv/hdr/interface_pre.erb:
    * ridlbe/c++11/templates/srv/hdr/interface_servant_traits.erb:
    * ridlbe/c++11/templates/srv/hdr/valuetype_pre.erb:
    * ridlbe/c++11/templates/srv/prx/interface_pre.erb: