### PR TITLE
Updated msvc version check and move comments to ruby code instead of …

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/interface_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_post.erb
@@ -17,12 +17,12 @@ protected:
       TAOX11_CORBA::abstractbase_reference<TAOX11_CORBA::AbstractBase>);
 #endif /* _MSC_VER < 1910 || clang <= 8 */
 
+%# msvc14.{0|1|2} have a problem with defaulted constructors, issue #4005
 #if defined (_MSC_VER) && (_MSC_VER < 1930)
-    // msvc 14.{0|1|2} have a problem with defaulted constructors, issue #4005
   <%= cxxname %> () {}
 #else
   <%= cxxname %> () = default;
-#endif /* _MSC_VER < 1920 */
+#endif /* _MSC_VER < 1930 */
   <%= cxxname %> (TAOX11_NAMESPACE::Abstractbase_proxy_ptr prx);
   virtual ~<%= cxxname %> () = default;
   /// Required for derived value types
@@ -81,7 +81,7 @@ protected:
 #else
   /// Default constructor
   <%= cxxname %> () = default;
-#endif /* _MSC_VER < 1920 */
+#endif /* _MSC_VER < 1930 */
   /// Destructor
   virtual ~<%= cxxname %> () = default;
 

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb
@@ -11,8 +11,8 @@ namespace obv
 % end
   {
   protected:
+%# msvc14.{0|1} have a problem with defaulted constructors, issue #4005
 #if defined (_MSC_VER) && (_MSC_VER < 1920)
-    // msvc14.(0|1) have a problem with defaulted constructors, issue #4005
     <%= cxxname %> () {}
 #else
     <%= cxxname %> () = default;


### PR DESCRIPTION
…generated code

    * ridlbe/c++11/templates/cli/hdr/interface_post.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb: