### PR TITLE
Removed redundant virtual keywords, override is already used

### DIFF
--- a/examples/ccs/server.h
+++ b/examples/ccs/server.h
@@ -138,11 +138,9 @@ public:
     virtual ~Thermostat_impl() = default;
 
     // CORBA operations
-    virtual CCS::TempType
-    get_nominal () override;
+    CCS::TempType get_nominal () override;
 
-    virtual CCS::TempType
-    set_nominal (CCS::TempType new_temp) override;
+    CCS::TempType set_nominal (CCS::TempType new_temp) override;
 
 private:
     // Copy and assignment not supported

--- a/tao/x11/anytypecode/anyinsert.h
+++ b/tao/x11/anytypecode/anyinsert.h
@@ -31,7 +31,7 @@ namespace TAOX11_NAMESPACE
 
     // Any insert  operations
 #define TAOX11_SYSTEM_EXCEPTION(name) \
-    virtual void insert_into_any (CORBA::Any * any, const CORBA::name &) override; \
+    void insert_into_any (CORBA::Any * any, const CORBA::name &) override; \
     // expand the list
     TAOX11_STANDARD_SYSTEM_EXCEPTION_LIST
     // undefine the template

--- a/tao/x11/dynamic_any/dynstruct_i.h
+++ b/tao/x11/dynamic_any/dynstruct_i.h
@@ -74,7 +74,7 @@ namespace TAOX11_NAMESPACE
 
       void destroy () override;
 
-      virtual IDL::traits< DynamicAny::DynAny>::ref_type current_component () override;
+      IDL::traits< DynamicAny::DynAny>::ref_type current_component () override;
 
     private:
       /// Check if the typecode is acceptable.

--- a/tao/x11/messaging/exception_holder_i.h
+++ b/tao/x11/messaging/exception_holder_i.h
@@ -36,9 +36,9 @@ namespace TAOX11_NAMESPACE
       ACE_Char_Codeset_Translator *char_translator,
       ACE_WChar_Codeset_Translator *wchar_translator);
 
-    virtual void raise_exception() override;
+    void raise_exception() override;
 
-    virtual void raise_exception_with_list (
+    void raise_exception_with_list (
         const ::TAOX11_NAMESPACE::Dynamic::ExceptionList& exc_list) override;
 
   protected:

--- a/tao/x11/portable_server/adapter_activator_cb.h
+++ b/tao/x11/portable_server/adapter_activator_cb.h
@@ -31,8 +31,8 @@ namespace TAOX11_NAMESPACE
 
       ~Adapter_Activator_Callback () = default;
 
-      virtual TAO_CORBA::Boolean unknown_adapter (TAO_PORTABLE_SERVER::POA_ptr parent,
-                                                  const char *name) override;
+      TAO_CORBA::Boolean unknown_adapter (TAO_PORTABLE_SERVER::POA_ptr parent,
+                                          const char *name) override;
 
       IDL::traits<PortableServer::AdapterActivator>::ref_type get_impl () const;
 

--- a/tests/collocation/diamond_i.h
+++ b/tests/collocation/diamond_i.h
@@ -46,7 +46,7 @@ public:
 
   virtual std::string color ();
 
-  virtual int32_t width () override;
+  int32_t width () override;
 };
 
 class DIAMOND_Export Bottom_i

--- a/tests/union/foo.h
+++ b/tests/union/foo.h
@@ -17,22 +17,22 @@ public:
   Foo (IDL::traits<CORBA::ORB>::ref_type orb);
 
   // = The skeleton methods
-  virtual bool pass_union (const Test::Data & s) override;
-  virtual bool pass_default_union (const Test::DefaultData & dd) override;
+  bool pass_union (const Test::Data & s) override;
+  bool pass_default_union (const Test::DefaultData & dd) override;
 
-  virtual Test::Data return_union () override;
-  virtual Test::DefaultData return_default_union () override;
-  virtual Test::X_Union return_x_union () override;
-  virtual Test::Y_Union return_y_union () override;
-  virtual Test::Z_Union return_z_union (const Test::Z_Union &z) override;
+  Test::Data return_union () override;
+  Test::DefaultData return_default_union () override;
+  Test::X_Union return_x_union () override;
+  Test::Y_Union return_y_union () override;
+  Test::Z_Union return_z_union (const Test::Z_Union &z) override;
 
-  virtual bool get_union (Test::Data & s) override;
-  virtual bool get_default_union (Test::DefaultData & dd) override;
+  bool get_union (Test::Data & s) override;
+  bool get_default_union (Test::DefaultData & dd) override;
 
-  virtual bool update_union (Test::Data & s) override;
-  virtual bool update_default_union (Test::DefaultData & dd) override;
+  bool update_union (Test::Data & s) override;
+  bool update_default_union (Test::DefaultData & dd) override;
 
-  virtual void shutdown () override;
+  void shutdown () override;
 
   uint16_t get_error_count ();
 


### PR DESCRIPTION
    * examples/ccs/server.h:
    * tao/x11/anytypecode/anyinsert.h:
    * tao/x11/dynamic_any/dynstruct_i.h:
    * tao/x11/messaging/exception_holder_i.h:
    * tao/x11/portable_server/adapter_activator_cb.h:
    * tests/collocation/diamond_i.h:
    * tests/union/foo.h: