### PR TITLE
Revert some uniform init, changed the default for the other constructors

### DIFF
--- a/tao/x11/logger/log_base.cpp
+++ b/tao/x11/logger/log_base.cpp
@@ -219,7 +219,10 @@ namespace x11_logger
     return std::addressof(instance_);
   }
 
-  Log_Module::Log_Module()
+  Log_Module::Log_Module() :
+    category_ ("X11"),
+    priority_mask_ (LP_PANIC),
+    output_mask_ (OS_STDERR)
   {
     // set default
     this->verbosity_mask_ =

--- a/tao/x11/logger/log_base.h
+++ b/tao/x11/logger/log_base.h
@@ -157,10 +157,10 @@ namespace x11_logger
     // to logfile base path and creation specs
     void build_file_path (long);
 
-    std::string const category_ { "X11" };
-    uint32_t priority_mask_ { LP_PANIC };
+    std::string const category_;
+    uint32_t priority_mask_ {};
     uint32_t verbosity_mask_ {};
-    uint32_t output_mask_ { OS_STDERR };
+    uint32_t output_mask_ {};
     std::string file_base_;
     uint32_t file_max_size_ {};
     uint32_t file_count_ {};

--- a/tests/log_test/readme.txt
+++ b/tests/log_test/readme.txt
@@ -4,9 +4,9 @@ In this test logging macro's of TAOX11 and the base X11 are used.
 
 Different settings of the priority masks and verbosity masks of TAOX11_LOGGER are used
 after each other. For this the setter operations of the priority_mask and verbosity_mask are used.
-The priority mask determine which macro's are enabled .
-The verbosity mask  determine the format of the output of the macro's .
+The priority mask determine which macro's are enabled.
+The verbosity mask  determine the format of the output of the macro's.
 
 We check automatically the right output of the macro's in the script $TAOX11_ROOT/tao/x11/logger/log_check.pl
-The script expected a blocks of code in a special order.  This is described in 
+The script expected a blocks of code in a special order.  This is described in
 $TAOX11_ROOT/tao/x11/logger/readme.txt


### PR DESCRIPTION
    * tao/x11/logger/log_base.cpp:
    * tao/x11/logger/log_base.h:
    * tests/log_test/readme.txt: