### PR TITLE
Extend union test with a more complex construct

### DIFF
--- a/tests/union/client.cpp
+++ b/tests/union/client.cpp
@@ -373,6 +373,35 @@ test_data_z (IDL::traits<Test::Foo>::ref_type foo)
   return retval;
 }
 
+uint16_t
+test_union_message (IDL::traits<Test::Foo>::ref_type foo)
+{
+  uint16_t retval = 0;
+
+  Test::Data dt_d;
+  Test::B03 b_d;
+
+  // Set the last item
+  b_d.b_03_5 ("XX");
+  dt_d.globalData (Global (4));
+
+  Test::UnionMessage msg_d { Test::Assignment::D, b_d, dt_d };
+
+  TAOX11_TEST_DEBUG << "Sending <"
+      << msg_d << ">" << std::endl;
+
+  bool const ret = foo->send_unionmessage (msg_d);
+
+  if (!ret)
+  {
+    TAOX11_TEST_ERROR << "ERROR: send_unionmessage returned false "
+      << std::endl;
+    ++retval;
+  }
+
+  return retval;
+}
+
 int main (int argc, char* argv[])
 {
   uint16_t retval = 0;
@@ -407,6 +436,7 @@ int main (int argc, char* argv[])
       retval += test_data_x (foo);
       retval += test_data_y (foo);
       retval += test_data_z (foo);
+      retval += test_union_message (foo);
 
       TAOX11_TEST_DEBUG << "shutting down..." << std::endl;
 

--- a/tests/union/foo.cpp
+++ b/tests/union/foo.cpp
@@ -169,6 +169,72 @@ Foo::update_default_union (Test::DefaultData & dd)
   return true;
 }
 
+bool
+Foo::send_unionmessage (const Test::UnionMessage & msg)
+{
+  TAOX11_TEST_DEBUG << "Received <" << msg << ">" << std::endl;
+
+  if (msg.a () != Test::Assignment::D)
+  {
+    TAOX11_TEST_ERROR << "Foo::send_unionmessage - ERROR - incorrect a received - "
+      << "expected <D> - received <" <<  msg.a () << ">" << std::endl;
+    ++this->errors_;
+  }
+
+  try
+  {
+    if (msg.b_03 ()._d () != 4)
+    {
+      TAOX11_TEST_ERROR << "Foo::send_unionmessage - ERROR - "
+        << "unexpected value for the discriminator detected. Expected <4> - got <"
+        << msg.b_03 ()._d () << ">." << std::endl;
+      ++this->errors_;
+    }
+
+    if (msg.b_03 ().b_03_5 () != "XX")
+    {
+      TAOX11_TEST_ERROR << "Foo::send_unionmessage - ERROR - "
+        << "unexpected value for the last member detected. Expected <XX> - got <"
+        << msg.b_03 ().b_03_5 () << ">." << std::endl;
+      ++this->errors_;
+    }
+  }
+  catch (const CORBA::BAD_PARAM&)
+  {
+    TAOX11_TEST_ERROR << "Foo::send_unionmessage - ERROR - "
+      << "Caught unexpected BAD_PARAM exception whilst examining <b_03>." << std::endl;
+    ++this->errors_;
+  }
+
+  // last member of d
+  try
+  {
+    if (msg.d ()._d () != Test::DataType::dtGlobal)
+    {
+      TAOX11_TEST_ERROR << "Foo::send_unionmessage - ERROR - "
+        << "unexpected value for the discriminator detected. Expected <Test::DataType::dtGlobal> - got <"
+        << msg.d ()._d () << ">." << std::endl;
+      ++this->errors_;
+    }
+
+    if (msg.d ().globalData ().x () != 4)
+    {
+      TAOX11_TEST_ERROR << "Foo::send_unionmessage - ERROR - "
+        << "unexpected value for the last member detected. Expected <4> - got <"
+        << msg.d ().globalData ().x () << ">." << std::endl;
+      ++this->errors_;
+    }
+  }
+  catch (const CORBA::BAD_PARAM&)
+  {
+    TAOX11_TEST_ERROR << "Foo::send_unionmessage - ERROR - "
+      << "Caught unexpected BAD_PARAM exception whilst examining <d>." << std::endl;
+    ++this->errors_;
+  }
+
+  return this->errors_ == 0;
+}
+
 void
 Foo::shutdown ()
 {

--- a/tests/union/foo.h
+++ b/tests/union/foo.h
@@ -32,6 +32,8 @@ public:
   bool update_union (Test::Data & s) override;
   bool update_default_union (Test::DefaultData & dd) override;
 
+  bool send_unionmessage (const Test::UnionMessage & msg) override;
+
   void shutdown () override;
 
   uint16_t get_error_count ();

--- a/tests/union/tao/foo.cpp
+++ b/tests/union/tao/foo.cpp
@@ -132,6 +132,13 @@ Foo::update_default_union (Test::DefaultData & dd)
   return true;
 }
 
+bool
+Foo::send_unionmessage (const Test::UnionMessage & /*msg*/)
+{
+  return true;
+}
+
+
 void
 Foo::shutdown ()
 {

--- a/tests/union/tao/foo.h
+++ b/tests/union/tao/foo.h
@@ -12,22 +12,24 @@ public:
   Foo (CORBA::ORB_ptr orb);
 
   // = The skeleton methods
-  virtual bool pass_union (const Test::Data & s);
-  virtual bool pass_default_union (const Test::DefaultData & dd);
+  bool pass_union (const Test::Data & s) override;
+  bool pass_default_union (const Test::DefaultData & dd) override;
 
-  virtual Test::Data * return_union ();
-  virtual Test::DefaultData return_default_union ();
-  virtual Test::X_Union * return_x_union ();
-  virtual Test::Y_Union * return_y_union ();
-  virtual Test::Z_Union * return_z_union (const Test::Z_Union & z);
+  Test::Data * return_union () override;
+  Test::DefaultData return_default_union () override;
+  Test::X_Union * return_x_union () override;
+  Test::Y_Union * return_y_union () override;
+  Test::Z_Union * return_z_union (const Test::Z_Union & z) override;
 
-  virtual bool get_union (Test::Data_out s);
-  virtual bool get_default_union (Test::DefaultData_out dd);
+  bool get_union (Test::Data_out s) override;
+  bool get_default_union (Test::DefaultData_out dd) override;
 
-  virtual bool update_union (Test::Data & s);
-  virtual bool update_default_union (Test::DefaultData & dd);
+  bool update_union (Test::Data & s);
+  bool update_default_union (Test::DefaultData & dd) override;
 
-  virtual void shutdown ();
+  bool send_unionmessage (const Test::UnionMessage & msg) override;
+
+  void shutdown () override;
 
 private:
   /// Use an ORB reference to convert strings to objects and shutdown

--- a/tests/union/tao/test.idl
+++ b/tests/union/tao/test.idl
@@ -78,6 +78,39 @@ module Test
       case 4: boolean z_bool;
     };
 
+  enum Assignment
+  {
+    NONE,
+    A,
+    B,
+    C,
+    D
+  };
+
+  struct B01 {
+    long b01_1;
+  };
+
+  struct B02 {
+    string b02_1;
+  };
+
+  union B03 switch (long)
+  {
+    case 0: B01 b_03_1;
+    case 1: B02 b_03_2;
+    case 2: short b_03_3;
+    case 3: long b_03_4;
+    case 4: string b_03_5;
+    default: short b_03_d;
+  };
+
+  struct UnionMessage {
+    Assignment a;
+    B03 b_03;
+    Data d;
+  };
+
   /// A very simple interface
   interface Foo
   {
@@ -95,6 +128,8 @@ module Test
 
     boolean update_union (inout Data s);
     boolean update_default_union (inout DefaultData dd);
+
+    boolean send_unionmessage(in UnionMessage msg);
 
     /// A method to shutdown the ORB
     /**

--- a/tests/union/test.idl
+++ b/tests/union/test.idl
@@ -142,6 +142,39 @@ module Test
       case 4: boolean z_bool;
     };
 
+  enum Assignment
+  {
+    NONE,
+    A,
+    B,
+    C,
+    D
+  };
+
+  struct B01 {
+    long b01_1;
+  };
+
+  struct B02 {
+    string b02_1;
+  };
+
+  union B03 switch (long)
+  {
+    case 0: B01 b_03_1;
+    case 1: B02 b_03_2;
+    case 2: short b_03_3;
+    case 3: long b_03_4;
+    case 4: string b_03_5;
+    default: short b_03_d;
+  };
+
+  struct UnionMessage {
+    Assignment a;
+    B03 b_03;
+    Data d;
+  };
+
   /// A very simple interface
   interface Foo
   {
@@ -159,6 +192,8 @@ module Test
 
     boolean update_union (inout Data s);
     boolean update_default_union (inout DefaultData dd);
+
+    boolean send_unionmessage(in UnionMessage msg);
 
     /// A method to shutdown the ORB
     /**


### PR DESCRIPTION
    * tests/union/client.cpp:
    * tests/union/foo.cpp:
    * tests/union/foo.h:
    * tests/union/tao/foo.cpp:
    * tests/union/tao/foo.h:
    * tests/union/tao/test.idl:
    * tests/union/test.idl: