### PR TITLE
Removed workarounds for gcc 4.7 and older and make use of TAOX11_IDL::bounded_(w)string

### DIFF
--- a/ridlbe/c++11/config/cxx_type.rb
+++ b/ridlbe/c++11/config/cxx_type.rb
@@ -391,7 +391,7 @@ module IDL
 
     class String
       def cxx_type(scope = nil)
-        (size.to_i>0) ? "TAOX11_IDL::bounded_basic_string<char, #{size}>" : 'std::string'
+        (size.to_i>0) ? "TAOX11_IDL::bounded_string<#{size}>" : 'std::string'
       end
       def proxy_cxxtype(scope = nil)
         cxx_type
@@ -403,7 +403,7 @@ module IDL
         "TAOX11_NAMESPACE::CORBA::#{cxx_typecode}"
       end
       def cxx_member_type_name
-        (size.to_i>0) ? "bounded_basic_string<char, #{size}>" : 'string'
+        (size.to_i>0) ? "bounded_string<#{size}>" : 'string'
       end
       def value_to_s(v, scope = nil)
         v.dump
@@ -418,7 +418,7 @@ module IDL
 
     class WString
       def cxx_type(scope = nil)
-        (size.to_i>0) ? "TAOX11_IDL::bounded_basic_string<wchar_t, #{size}>" : 'std::wstring'
+        (size.to_i>0) ? "TAOX11_IDL::bounded_wstring<#{size}>" : 'std::wstring'
       end
       def proxy_cxxtype(scope = nil)
         cxx_type
@@ -430,7 +430,7 @@ module IDL
         "TAOX11_NAMESPACE::CORBA::#{cxx_typecode}"
       end
       def cxx_member_type_name
-        (size.to_i>0) ? "bounded_basic_string<wchar_t, #{size}>" : 'wstring'
+        (size.to_i>0) ? "bounded_wstring<#{size}>" : 'wstring'
       end
       def value_to_s(v, scope = nil)
         return 'L'+v.to_s.dump unless ::Array === v

--- a/tao/x11/bounded_string_t.h
+++ b/tao/x11/bounded_string_t.h
@@ -346,13 +346,11 @@ namespace TAOX11_NAMESPACE
         { this->_String::swap (__x); }
       };
 
-#if defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7))
     template <const uint32_t _Bound>
       using bounded_string = bounded_basic_string<char, _Bound>;
 
     template <const uint32_t _Bound>
       using bounded_wstring = bounded_basic_string<wchar_t, _Bound>;
-#endif
 
     template<typename _CharT, const uint32_t _Bound, typename _Traits, typename _Alloc>
       bounded_basic_string<_CharT, _Bound, _Traits, _Alloc>

--- a/tao/x11/ext/std_to_string.h
+++ b/tao/x11/ext/std_to_string.h
@@ -13,11 +13,6 @@
 #pragma message ("warning: This file should not be included by user code directly. Please remove the include from your code")
 #endif
 
-#if defined(__MINGW32__) && !defined(__MINGW64__)
-# if (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 8))
-#   define TAOX11_LACKS_STD_TO_STRING
-# endif /* __GNUC__ < 4.8 */
-#endif /* defined(__MINGW32__) && !defined(__MINGW64__) */
 #if defined(__ANDROID_API__)
 # define TAOX11_LACKS_STD_TO_STRING
 #endif /* defined (__ANDROID_API__) */


### PR DESCRIPTION
    * tao/x11/bounded_string_t.h:
    * tao/x11/ext/std_to_string.h: