### PR TITLE
No need to set c++11=1 and no_deprecated=0 anymore

### DIFF
--- a/bin/MPC/config/taox11_basedefaults.mpb
+++ b/bin/MPC/config/taox11_basedefaults.mpb
@@ -6,8 +6,6 @@ project : taox11_rules {
   libpaths += $(X11_BASE_ROOT)/lib
 
   verbatim(gnuace,macros,1) {
-    c++11=1
     taox11_build?=1
-    no_deprecated=0
   }
 }


### PR DESCRIPTION
    * bin/MPC/config/taox11_basedefaults.mpb: