### PR TITLE
Fix warnings when the array default/first member is an array of pod

### DIFF
--- a/ridlbe/c++11/templates/cli/inl/union_inl.erb
+++ b/ridlbe/c++11/templates/cli/inl/union_inl.erb
@@ -2,9 +2,9 @@
 
 inline <%= scoped_cxxname %>::u_type_::u_type_ ()
 % if has_default?()
-  : <%= default_member.cxxname %>_ {}
+  : <%= default_member.cxxname %>_ <% if default_member.is_array_of_pod? %>{{}}<% else %>{}<% end %>
 % else
-  : <%= members.first.cxxname %>_ {}
+  : <%= members.first.cxxname %>_ <% if members.first.is_array_of_pod? %> {{}}<% else %>{}<% end %>
 % end
 {
 }

--- a/ridlbe/c++11/visitors/union.rb
+++ b/ridlbe/c++11/visitors/union.rb
@@ -152,6 +152,10 @@ module IDL
       def is_default?
         node.labels.include?(:default)
       end
+
+      def is_array_of_pod?
+        IDL::Type::Array === _resolved_idltype && _resolved_idltype.basetype.is_pod?
+      end
     end
 
   end


### PR DESCRIPTION
    * ridlbe/c++11/templates/cli/inl/union_inl.erb:
    * ridlbe/c++11/visitors/union.rb: