### PR TITLE
Validate that narrowing a nil reference returns nil

### DIFF
--- a/tests/dynany/test_dynarray.cpp
+++ b/tests/dynany/test_dynarray.cpp
@@ -37,6 +37,15 @@ Test_DynArray::run_test ()
   {
     TAOX11_TEST_DEBUG << "*=*=*=*= " << data.labels[4] << " =*=*=*=*" << std::endl;
 
+    IDL::traits<DynamicAny::DynArray>::ref_type dyn_nil =
+      IDL::traits<DynamicAny::DynArray>::narrow (nullptr);
+
+    if (dyn_nil)
+    {
+      ++this->error_count_;
+      TAOX11_TEST_ERROR << "DynArray::narrow(nil) should return nil" << std::endl;
+    }
+
     IDL::traits<CORBA::Object>::ref_type factory_obj =
                     this->orb_->resolve_initial_references ("DynAnyFactory");
 
@@ -46,7 +55,6 @@ Test_DynArray::run_test ()
                         << std::endl;
      return 1;
     }
-
 
     IDL::traits< DynamicAny::DynAnyFactory>::ref_type dynany_factory =
         IDL::traits< DynamicAny::DynAnyFactory>::narrow (factory_obj);
@@ -112,7 +120,6 @@ Test_DynArray::run_test ()
     in_any2 <<= ta;
 
     ftc1->from_any (in_any2);
-
 
     analyzer.analyze (ftc1);
 

--- a/tests/dynany/test_dynenum.cpp
+++ b/tests/dynany/test_dynenum.cpp
@@ -32,6 +32,15 @@ Test_DynEnum::run_test ()
 
   try
   {
+    IDL::traits<DynamicAny::DynEnum>::ref_type dyn_nil =
+      IDL::traits<DynamicAny::DynEnum>::narrow (nullptr);
+
+    if (dyn_nil)
+    {
+      ++this->error_count_;
+      TAOX11_TEST_ERROR << "DynEnum::narrow(nil) should return nil" << std::endl;
+    }
+
     IDL::traits<CORBA::Object>::ref_type factory_obj =
           this->orb_->resolve_initial_references ("DynAnyFactory");
 
@@ -41,7 +50,6 @@ Test_DynEnum::run_test ()
                         << std::endl;
      return -1;
     }
-
 
     IDL::traits< DynamicAny::DynAnyFactory>::ref_type dynany_factory =
         IDL::traits< DynamicAny::DynAnyFactory>::narrow (factory_obj);

--- a/tests/dynany/test_dynsequence.cpp
+++ b/tests/dynany/test_dynsequence.cpp
@@ -60,6 +60,14 @@ Test_DynSequence::run_test ()
 
   try
   {
+    IDL::traits<DynamicAny::DynSequence>::ref_type dyn_nil =
+      IDL::traits<DynamicAny::DynSequence>::narrow (nullptr);
+
+    if (dyn_nil)
+    {
+      ++this->error_count_;
+      TAOX11_TEST_ERROR << "DynSequence::narrow(nil) should return nil" << std::endl;
+    }
 
     IDL::traits<CORBA::Object>::ref_type factory_obj =
              this->orb_->resolve_initial_references ("DynAnyFactory");

--- a/tests/dynany/test_dynstruct.cpp
+++ b/tests/dynany/test_dynstruct.cpp
@@ -38,6 +38,15 @@ Test_DynStruct::run_test ()
 
   try
   {
+    IDL::traits<DynamicAny::DynStruct>::ref_type dyn_nil =
+      IDL::traits<DynamicAny::DynStruct>::narrow (nullptr);
+
+    if (dyn_nil)
+    {
+      ++this->error_count_;
+      TAOX11_TEST_ERROR << "DynStruct::narrow(nil) should return nil" << std::endl;
+    }
+
     IDL::traits<CORBA::Object>::ref_type factory_obj =
                     this->orb_->resolve_initial_references ("DynAnyFactory");
 

--- a/tests/dynany/test_dynunion.cpp
+++ b/tests/dynany/test_dynunion.cpp
@@ -34,6 +34,15 @@ Test_DynUnion::run_test ()
 
   try
   {
+    IDL::traits<DynamicAny::DynUnion>::ref_type dyn_nil =
+      IDL::traits<DynamicAny::DynUnion>::narrow (nullptr);
+
+    if (dyn_nil)
+    {
+      ++this->error_count_;
+      TAOX11_TEST_ERROR << "DynUnion::narrow(nil) should return nil" << std::endl;
+    }
+
     IDL::traits<CORBA::Object>::ref_type factory_obj =
                this->orb_->resolve_initial_references ("DynAnyFactory");
 

--- a/tests/dynany/test_dynvalue.cpp
+++ b/tests/dynany/test_dynvalue.cpp
@@ -32,6 +32,15 @@ Test_DynValue::run_test ()
 
   try
   {
+    IDL::traits<DynamicAny::DynValue>::ref_type dyn_nil =
+      IDL::traits<DynamicAny::DynValue>::narrow (nullptr);
+
+    if (dyn_nil)
+    {
+      ++this->error_count_;
+      TAOX11_TEST_ERROR << "DynValue::narrow(nil) should return nil" << std::endl;
+    }
+
     IDL::traits<CORBA::Object>::ref_type factory_obj =
                     this->orb_->resolve_initial_references ("DynAnyFactory");
 


### PR DESCRIPTION
    * tests/dynany/test_dynarray.cpp:
    * tests/dynany/test_dynenum.cpp:
    * tests/dynany/test_dynsequence.cpp:
    * tests/dynany/test_dynstruct.cpp:
    * tests/dynany/test_dynunion.cpp:
    * tests/dynany/test_dynvalue.cpp: