### PR TITLE
Fixed typos using https://github.com/crate-ci/typos

### DIFF
--- a/brix/taox11/docs/generate_client.rd
+++ b/brix/taox11/docs/generate_client.rd
@@ -51,7 +51,7 @@ $ brix11 gen cli
 
 Generates a standard client main file 'client.cpp' using any IDL file in the project directory,
 attempting to resolve a servant IOR to an interface with name derived from the first IDL file and
-issueing a standard 'shutdown' request.
+issuing a standard 'shutdown' request.
 
 $ brix11 gen cli -I special_test --without-shutdown special_client
 
@@ -61,4 +61,4 @@ resolve a servant IOR to the interface 'Special_test' without standard 'shutdown
 $ brix11 gen cli -i MyModule::MyInterface -I hello
 
 Generates a client main file 'client.cpp' including 'helloC.h' attempting to resolve a servant
-IOR to the interface 'MyModule::MyInterface' and issueing a standard 'shutdown' request.
+IOR to the interface 'MyModule::MyInterface' and issuing a standard 'shutdown' request.

--- a/tao/x11/dynamic_any/dynvalue_i.cpp
+++ b/tao/x11/dynamic_any/dynvalue_i.cpp
@@ -112,7 +112,7 @@ namespace TAOX11_NAMESPACE
         this->component_count_);
       this->da_members_.resize (this->component_count_);
 
-      // And initalize all of the DynCommon mix-in
+      // And initialize all of the DynCommon mix-in
 
       this->init_common ();
     }
@@ -125,7 +125,7 @@ namespace TAOX11_NAMESPACE
     {
       TAOX11_LOG_TRACE ("DynValue_i::get_base_types");
 
-      // First initalize to the fully derived type we are
+      // First initialize to the fully derived type we are
       // starting with.
 
       base_types.push_back (DynAnyFactory_i::strip_alias (tc));
@@ -551,7 +551,7 @@ namespace TAOX11_NAMESPACE
     // (even though we are a constructed type and should do
     // so with any other type of input). If we don't assume
     // the value type is for us, it will get passed down
-    // (recursivly) to the terminal non-valuetype member
+    // (recursively) to the terminal non-valuetype member
     // which then will be wrong type for the valuetype input
     // we started with.
     void
@@ -604,7 +604,7 @@ namespace TAOX11_NAMESPACE
     // (even though we are a constructed type and should
     // do so with any other type of output). If we don't
     // assume the value type is us, it will get passed down
-    // (recursivly) to the terminal non-valuetype member
+    // (recursively) to the terminal non-valuetype member
     // which then will be wrong type for the valuetype
     // output we want.
     IDL::traits<CORBA::ValueBase>::ref_type
@@ -708,7 +708,7 @@ namespace TAOX11_NAMESPACE
       // with DynValue * instead. However the pointer isn't
       // actually dereferanced by the _tao_write_special_value()
       // call, its address (as a void *) is just used to
-      // check for the null value and any previous writen
+      // check for the null value and any previous written
       // value for the indirection header and the saving of
       // this current location for this new valuetype if it
       // is not indirected (this time).
@@ -906,7 +906,7 @@ namespace TAOX11_NAMESPACE
               <= ++currentBaseMember)
           {
             // Remind us to start again with the next derived type
-            // for the next member to be writen.
+            // for the next member to be written.
             currentBaseMember= 0u;
 
             // We must end the chunk we started for this
@@ -921,7 +921,7 @@ namespace TAOX11_NAMESPACE
           }
         }
         // Write out the end chunking markers for the number
-        // of base types we have writen.
+        // of base types we have written.
         for (i= 1u; i < trunc_ids; ++i)
         {
           if (!ci.end_chunk (out_cdr))
@@ -975,7 +975,7 @@ namespace TAOX11_NAMESPACE
       }
       if (is_indirected)
       {
-        // Effectivly this member? is the same ValueType as previous
+        // Effectively this member? is the same ValueType as previous
         // seen either in another member of this container OR the
         // whole container itself. (Possiably can happen as a
         // circular linked list?)
@@ -1181,7 +1181,7 @@ namespace TAOX11_NAMESPACE
               <= ++currentBaseMember)
         {
           // Remind us to start again with the next derived type
-          // for the next member to be writen.
+          // for the next member to be written.
           currentBaseMember= 0u;
           if (currentBase < num_ids)
           {

--- a/tao/x11/ifr_client_adapter.cpp
+++ b/tao/x11/ifr_client_adapter.cpp
@@ -2,7 +2,7 @@
  * @file    ifr_client_adapter.cpp
  * @author  Martin Corino
  *
- * @brief   Implementatin of the IFR Client Adapter
+ * @brief   Implementation of the IFR Client Adapter
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
  */

--- a/tao/x11/logger/logstream_t.h
+++ b/tao/x11/logger/logstream_t.h
@@ -117,7 +117,7 @@ namespace x11_logger
   /**
   * @class log_ostream_t
   *
-  * @brief TAOX11 basic_ostream specializaton
+  * @brief TAOX11 basic_ostream specialization
   */
   template <typename CH, typename TR = std::char_traits<CH> >
   class log_ostream_t

--- a/tests/ami_test/ami/client.cpp
+++ b/tests/ami_test/ami/client.cpp
@@ -481,7 +481,7 @@ int main(int argc, char* argv[])
            (callback_excep != 5 ) ||
            (callback_attrib != 4 ))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected callbacks."
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected callbacks."
           << " Foo : expected -4- , received -" << callback_operation << "-"
           << " Attrib : expected -4-, received -" << callback_attrib << "-"
           << " Exceptions: expected -5-, received -" << callback_excep << "-."

--- a/tests/ami_test/ami/tao/client.cpp
+++ b/tests/ami_test/ami/tao/client.cpp
@@ -444,7 +444,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
            (callback_excep != 5 ) ||
            (callback_attrib != 4 ))
         {
-          ACE_ERROR ((LM_ERROR, "ERROR: Client didn't recieve expected callbacks. "
+          ACE_ERROR ((LM_ERROR, "ERROR: Client didn't receive expected callbacks. "
                     "Foo: expected -4- received -%d-, "
                     "Attrib: expected -4-, received -%d-, "
                     "Exceptions: expected -5-, received -%d-\n",

--- a/tests/ami_test/ami_collocation/collocation_tester.cpp
+++ b/tests/ami_test/ami_collocation/collocation_tester.cpp
@@ -54,7 +54,7 @@ Collocation_Test::shutdown ()
   int result {};
   if (callback_operation != 6)
   {
-    TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected callbacks."
+    TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected callbacks."
         << " Foo : expected -6- , received -" << callback_operation << "-"
         << std::endl;
     result = 1;

--- a/tests/ami_test/ami_in_out_inout/client.cpp
+++ b/tests/ami_test/ami_in_out_inout/client.cpp
@@ -693,7 +693,7 @@ int main(int argc, char* argv[])
 
       if (callback_operation != 20)
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected callbacks."
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected callbacks."
           << " Expected -20- , received -" << callback_operation
           << std::endl;
           result = 1;

--- a/tests/ami_test/ami_naming/client.cpp
+++ b/tests/ami_test/ami_naming/client.cpp
@@ -641,7 +641,7 @@ int main(int argc, char* argv[])
           (callback_sendc_ami_foo != 1) || (callback_attrib != 8 ) ||
           (callback_foo_two != 1) || (callback_do != 1))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected callbacks. Foo : expected -2- , received -" << callback_foo << "-"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected callbacks. Foo : expected -2- , received -" << callback_foo << "-"
           << " sendc_foo : expected -1-, received -" << callback_sendc_foo << "-."
           << " sendc_ami_foo : expected -1-, received -" << callback_sendc_ami_foo << "-."
           << " foo_two : expected -1-, received -" << callback_foo_two << "-."

--- a/tests/ami_test/annotations/client.cpp
+++ b/tests/ami_test/annotations/client.cpp
@@ -271,7 +271,7 @@ int main(int argc, char* argv[])
 
       if ((callback_foo != 2) || (callback_attrib != 2 ))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected callbacks. Foo : expected -2- , received -" << callback_foo << "-"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected callbacks. Foo : expected -2- , received -" << callback_foo << "-"
           << " Attrib : expected -2-, received -" << callback_attrib << "-."
           << std::endl;
           result = 1;

--- a/tests/ami_test/attr_raises/client.cpp
+++ b/tests/ami_test/attr_raises/client.cpp
@@ -758,7 +758,7 @@ int main(int argc, char* argv[])
 
       if ((callback_foo != 3) || (callback_excep != 11 ) || (callback_attrib != 11 ))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected callbacks. Foo : expected -3- , received -" << callback_foo << "-"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected callbacks. Foo : expected -3- , received -" << callback_foo << "-"
           << " Attrib : expected -11-, received -" << callback_attrib << "-"
           << " Exceptions: expected -11-, received -" << callback_excep << "-."<< std::endl;
           result = 1;

--- a/tests/ami_test/derived/client.cpp
+++ b/tests/ami_test/derived/client.cpp
@@ -523,7 +523,7 @@ int main(int argc, char* argv[])
 
       if ((nr_of_replies != 0) || (myfoo_foo != 1) || (mybar_foo != 1))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected replies. Expected -12- , received -"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected replies. Expected -12- , received -"
           << (5 - nr_of_replies) << "-. " << " Expected MyFoo- foo <1> , received <"
           << myfoo_foo << ">. Expected MyBar- foo <1>, received <" << mybar_foo << ">." << std::endl;
           result = 1;
@@ -531,7 +531,7 @@ int main(int argc, char* argv[])
 
       if ((myfoo_attrib != 2) || (mybar_attrib != 2))
          {
-           TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected replies on my_foo_attrib. "
+           TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected replies on my_foo_attrib. "
            << "Expected MyFoo- my_foo_attrib <2> , received <"
            << myfoo_attrib << ">. Expected MyBar- my_foo_attrib <2>, received <"
            << mybar_attrib << ">." << std::endl;
@@ -540,7 +540,7 @@ int main(int argc, char* argv[])
 
       if ((myfoo_foo_excep != 1) || (mybar_foo_excep != 2))
           {
-            TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected exceptions on my_foo. "
+            TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected exceptions on my_foo. "
             << "Expected MyFoo- my_foo_excep <1> , received <"
             << myfoo_foo_excep << ">. Expected MyBar- my_foo_excep <2>, received <"
             << mybar_foo_excep << ">." << std::endl;

--- a/tests/ami_test/exceptions/client.cpp
+++ b/tests/ami_test/exceptions/client.cpp
@@ -365,7 +365,7 @@ int main(int argc, char* argv[])
 
       if ((callback != 4) || (callback_excep != 3 ))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected callbacks. Callbacks expected -4- , received -" << callback << "-"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected callbacks. Callbacks expected -4- , received -" << callback << "-"
           << " Exceptions: expected -3-, received -" << callback_excep << "-."<< std::endl;
           result = 1;
         }

--- a/tests/ami_test/keywords/client.cpp
+++ b/tests/ami_test/keywords/client.cpp
@@ -12,7 +12,7 @@
 
 uint16_t result_ = 0;
 
-uint16_t replies_to_recieve_ = 10;
+uint16_t replies_to_receive_ = 10;
 uint16_t received_replies_ = 0;
 
 template<class T>
@@ -588,14 +588,14 @@ int main(int argc, char* argv[])
 
       // Wait until all methods/setters have returned before getting the values of the
       // attributes.
-      while (received_replies_ != replies_to_recieve_)
+      while (received_replies_ != replies_to_receive_)
         {
           std::chrono::seconds tv (1);
           orb->perform_work (tv);
         }
 
       // reset for the next test.
-      replies_to_recieve_ = 7;
+      replies_to_receive_ = 7;
       received_replies_ = 0;
 
       TAOX11_TEST_DEBUG << "Getting the attributes asynchronously." << std::endl;
@@ -609,7 +609,7 @@ int main(int argc, char* argv[])
 
       hello->sendc_bar (nullptr);
 
-      while (received_replies_ != replies_to_recieve_)
+      while (received_replies_ != replies_to_receive_)
         {
           std::chrono::seconds tv (1);
           orb->perform_work (tv);

--- a/tests/ami_test/keywords/keywords.doxygen
+++ b/tests/ami_test/keywords/keywords.doxygen
@@ -1681,7 +1681,7 @@ UML_LOOK               = NO
 # the class node. If there are many fields or methods and many nodes the
 # graph may become too big to be useful. The UML_LIMIT_NUM_FIELDS
 # threshold limits the number of items for each type to make the size more
-# managable. Set this to 0 for no limit. Note that the threshold may be
+# manageable. Set this to 0 for no limit. Note that the threshold may be
 # exceeded by 50% before the limit is enforced.
 
 UML_LIMIT_NUM_FIELDS   = 10

--- a/tests/ami_test/mix_ami_noami/client.cpp
+++ b/tests/ami_test/mix_ami_noami/client.cpp
@@ -269,7 +269,7 @@ int main(int argc, char* argv[])
 
       if ((nr_of_replies != 0) || (ami_myfoo_foo != 1) || (myfoo_foo != 1))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected replies. Expected -3- , received -"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected replies. Expected -3- , received -"
           << (3 - nr_of_replies) << "-. " << " Expected AmiMyFoo- foo <1> , received <"
           << ami_myfoo_foo << ">. Expected MyFoo- foo <1>, received <" << myfoo_foo << ">." << std::endl;
           result = 1;

--- a/tests/ami_test/mix_annotation_pragma/client.cpp
+++ b/tests/ami_test/mix_annotation_pragma/client.cpp
@@ -525,7 +525,7 @@ int main(int argc, char* argv[])
 
       if ((nr_of_replies != 0) || (myfoo_foo != 1) || (mybar_foo != 1))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected replies. Expected -12- , received -"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected replies. Expected -12- , received -"
           << (5 - nr_of_replies) << "-. " << " Expected MyFoo- foo <1> , received <"
           << myfoo_foo << ">. Expected MyBar- foo <1>, received <" << mybar_foo << ">." << std::endl;
           result = 1;
@@ -533,7 +533,7 @@ int main(int argc, char* argv[])
 
       if ((myfoo_attrib != 2) || (mybar_attrib != 2))
          {
-           TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected replies on my_foo_attrib. "
+           TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected replies on my_foo_attrib. "
            << "Expected MyFoo- my_foo_attrib <2> , received <"
            << myfoo_attrib << ">. Expected MyBar- my_foo_attrib <2>, received <"
            << mybar_attrib << ">." << std::endl;
@@ -542,7 +542,7 @@ int main(int argc, char* argv[])
 
       if ((myfoo_foo_excep != 1) || (mybar_foo_excep != 2))
           {
-            TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected exceptions on my_foo. "
+            TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected exceptions on my_foo. "
             << "Expected MyFoo- my_foo_excep <1> , received <"
             << myfoo_foo_excep << ">. Expected MyBar- my_foo_excep <2>, received <"
             << mybar_foo_excep << ">." << std::endl;

--- a/tests/ami_test/multi_idl_mix_2client/client2.cpp
+++ b/tests/ami_test/multi_idl_mix_2client/client2.cpp
@@ -248,7 +248,7 @@ int main(int argc, char* argv[])
 
       if ((nr_of_replies != 0))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client2 didn't recieve expected replies. Expected -1- , received -"
+          TAOX11_TEST_ERROR << "ERROR: Client2 didn't receive expected replies. Expected -1- , received -"
           << (1 - nr_of_replies) << "-. " << std::endl;
           result = 1;
         }

--- a/tests/ami_test/multiple_idl_ami/client.cpp
+++ b/tests/ami_test/multiple_idl_ami/client.cpp
@@ -344,7 +344,7 @@ int main(int argc, char* argv[])
 
       if ((nr_of_replies != 0) || (cb_a != 1) || (cb_b != 1))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected replies. Expected -3- , received -"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected replies. Expected -3- , received -"
           << (3 - nr_of_replies) << "-. " << " Expected A callbacks <1> , received <"
           << cb_a << ">. Expected B callbacks <1>, received <" << cb_b << ">." << std::endl;
           result = 1;
@@ -352,7 +352,7 @@ int main(int argc, char* argv[])
 
       if (cb_a_excep != 1)
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected  exceptions. "
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected  exceptions. "
             << "Expected A callbacks exceptions <1> , received <"
             << cb_a_excep << ">." << std::endl;
             result = 1;

--- a/tests/ami_test/multiple_idl_derived/client.cpp
+++ b/tests/ami_test/multiple_idl_derived/client.cpp
@@ -343,7 +343,7 @@ int main(int argc, char* argv[])
 
       if ((nr_of_replies != 0) || (cb_a != 2) || (cb_b != 1))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected replies. Expected -3- , received -"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected replies. Expected -3- , received -"
           << (3 - nr_of_replies) << "-. " << " Expected A callbacks <2> , received <"
           << cb_a << ">. Expected B callbacks <1>, received <" << cb_b << ">." << std::endl;
           result = 1;

--- a/tests/ami_test/multiple_idl_derived_gca/client.cpp
+++ b/tests/ami_test/multiple_idl_derived_gca/client.cpp
@@ -343,7 +343,7 @@ int main(int argc, char* argv[])
 
       if ((nr_of_replies != 0) || (cb_a != 2) || (cb_b != 1))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected replies. Expected -3- , received -"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected replies. Expected -3- , received -"
           << (3 - nr_of_replies) << "-. " << " Expected A callbacks <2> , received <"
           << cb_a << ">. Expected B callbacks <1>, received <" << cb_b << ">." << std::endl;
           result = 1;

--- a/tests/ami_test/multiple_idl_mix/client.cpp
+++ b/tests/ami_test/multiple_idl_mix/client.cpp
@@ -275,7 +275,7 @@ int main(int argc, char* argv[])
 
       if ((nr_of_replies != 0) || (cb_a != 1))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected replies. Expected -2- , received -"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected replies. Expected -2- , received -"
           << (2 - nr_of_replies) << "-. " << " Expected A callbacks <1> , received <"
           << cb_a << ">." << std::endl;
           result = 1;
@@ -283,7 +283,7 @@ int main(int argc, char* argv[])
 
       if (cb_a_excep != 1)
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected  exceptions. "
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected  exceptions. "
             << "Expected A callbacks exceptions <1> , received <"
             << cb_a_excep << ">." << std::endl;
             result = 1;

--- a/tests/ami_test/multiple_idl_mix_gca/client.cpp
+++ b/tests/ami_test/multiple_idl_mix_gca/client.cpp
@@ -281,7 +281,7 @@ int main(int argc, char* argv[])
 
       if ((nr_of_replies != 0) || (cb_a != 1))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected replies. Expected -2- , received -"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected replies. Expected -2- , received -"
           << (2 - nr_of_replies) << "-. " << " Expected A callbacks <1> , received <"
           << cb_a << ">." << std::endl;
           result = 1;
@@ -289,7 +289,7 @@ int main(int argc, char* argv[])
 
       if (cb_a_excep != 1)
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected  exceptions. "
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected  exceptions. "
             << "Expected A callbacks exceptions <1> , received <"
             << cb_a_excep << ">." << std::endl;
             result = 1;

--- a/tests/ami_test/multiple_inherit/client.cpp
+++ b/tests/ami_test/multiple_inherit/client.cpp
@@ -635,7 +635,7 @@ int main(int argc, char* argv[])
 
       if ((nr_of_replies != 0) || (id_o != 4) || (ic_o != 2))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected replies. Expected -12- , received -"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected replies. Expected -12- , received -"
           << (12 - nr_of_replies) << "-. " << " Expected D callbacks <4> , received <"
           << id_o << ">. Expected C callbacks <2>, received <" << ic_o << ">." << std::endl;
           result = 1;
@@ -643,7 +643,7 @@ int main(int argc, char* argv[])
 
       if ((id_excep != 4) || (ic_excep != 2))
          {
-           TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected  exceptions. "
+           TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected  exceptions. "
             << "Expected D callbacks exceptions <4> , received <"
             << id_excep << ">. Expected C callbacks exceptions <2>, received <"
             << ic_excep << ">." << std::endl;

--- a/tests/ami_test/no_module/client.cpp
+++ b/tests/ami_test/no_module/client.cpp
@@ -677,7 +677,7 @@ int main(int argc, char* argv[])
          (callback_attrib_der != 1 ) ||
          (callback_operation_der != 1 ))
     {
-      TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected callbacks."
+      TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected callbacks."
       << " Foo : expected -4- , received -" << callback_operation << "-"
       << " do_something : expected -1- , received -" << callback_operation_der << "-"
       << " Attrib : expected -4-, received -" << callback_attrib << "-"

--- a/tests/ami_test/replyhandler/client.cpp
+++ b/tests/ami_test/replyhandler/client.cpp
@@ -448,7 +448,7 @@ int main(int argc, char* argv[])
 
       if ((callback_foo != 2) || (callback_attrib != 6 ))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected callbacks. Foo : expected -2- , received -" << callback_foo << "-"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected callbacks. Foo : expected -2- , received -" << callback_foo << "-"
           << " Attrib : expected -6-, received -" << callback_attrib << "-."
           << std::endl;
           result = 1;

--- a/tests/ami_test/use_of_gca/client.cpp
+++ b/tests/ami_test/use_of_gca/client.cpp
@@ -358,7 +358,7 @@ int main(int argc, char* argv[])
 
       if ((callback_foo != 2) || (callback_excep != 3 ) || (callback_attrib != 2 ))
         {
-          TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected callbacks. Foo : expected -2- , received -" << callback_foo << "-"
+          TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected callbacks. Foo : expected -2- , received -" << callback_foo << "-"
           << " Attrib : expected -2-, received -" << callback_attrib << "-"
           << " Exceptions: expected -3-, received -" << callback_excep << "-."<< std::endl;
           result = 1;

--- a/tests/ami_test/weak_ref/client.cpp
+++ b/tests/ami_test/weak_ref/client.cpp
@@ -283,7 +283,7 @@ int main(int argc, char* argv[])
 
         if (callback_operation != 2)
           {
-            TAOX11_TEST_ERROR << "ERROR: Client didn't recieve expected callbacks."
+            TAOX11_TEST_ERROR << "ERROR: Client didn't receive expected callbacks."
             << " expected -2- , received -" << callback_operation << "-."
             << std::endl;
             result = 1;

--- a/tests/idl_test/idl_test.mpc
+++ b/tests/idl_test/idl_test.mpc
@@ -4,7 +4,7 @@ project(*IDL): ridl_ostream_defaults, taox11_messaging {
   custom_only=1
   //Use of -GCa i.o. -GC, because -GC expects with taox11 ami pragma's or annotations
   //and we don't want to change all idl files of this test, so use
-  //-GCa wich is added to taox11 for backwards compatibility.
+  //-GCa which is added to taox11 for backwards compatibility.
   idlflags += -GCa -Gd
   //-GH
   //-GT

--- a/tests/idl_test/main.cpp
+++ b/tests/idl_test/main.cpp
@@ -68,7 +68,7 @@ class schmegegging_i : public virtual gleep::schmegegging
 {
 };
 
-// TODO: when anynomous times are enabled
+// TODO: when anonymous times are enabled
 // struct something_handler
 //   : public CORBA::servant_traits<bug_1985_c::d::AMI_somethingHandler>
 // {

--- a/tests/poa/children/children.cpp
+++ b/tests/poa/children/children.cpp
@@ -129,7 +129,7 @@ main (int argc, char *argv[])
                               policies);
       if (first_poa)
         {
-          TAOX11_TEST_INFO << "Succesfully created <" << FIRST_POA
+          TAOX11_TEST_INFO << "Successfully created <" << FIRST_POA
                       << ">." << std::endl;
         }
       else
@@ -148,7 +148,7 @@ main (int argc, char *argv[])
                                policies);
       if (second_poa)
         {
-          TAOX11_TEST_INFO << "Succesfully created <" << SECOND_POA
+          TAOX11_TEST_INFO << "Successfully created <" << SECOND_POA
                       << ">." << std::endl;
         }
       else
@@ -175,7 +175,7 @@ main (int argc, char *argv[])
                               CORBA::PolicyList ());
       if (third_poa)
         {
-          TAOX11_TEST_INFO << "Succesfully created <" << THIRD_POA
+          TAOX11_TEST_INFO << "Successfully created <" << THIRD_POA
                       << ">." << std::endl;
         }
       else

--- a/tests/poa/findpoa/findpoa.cpp
+++ b/tests/poa/findpoa/findpoa.cpp
@@ -12,7 +12,7 @@
 #include "tao/x11/portable_server/portableserver_impl.h"
 #include "tao/x11/portable_server/AdapterActivatorC.h"
 
-bool find_non_existant_POA(IDL::traits<PortableServer::POA>::ref_type parent,
+bool find_non_existent_POA(IDL::traits<PortableServer::POA>::ref_type parent,
     const std::string& child_poa_name, bool activate)
 {
   // New environment.
@@ -107,7 +107,7 @@ int main (int argc, char *argv[])
 
       // Try to find a non-existent POA.  Since the Adapter Activator
       // has not been installed yet, this call should fail.
-      if (!find_non_existant_POA (root_poa, "firstPOA", true) )
+      if (!find_non_existent_POA (root_poa, "firstPOA", true) )
         return 1;
 
       // Get a TAO_Adapter_Activator reference
@@ -193,7 +193,7 @@ int main (int argc, char *argv[])
       // Activator has been installed, this call should fail because
       // the activate (if not found) flag is 0.
       TAOX11_TEST_DEBUG << "test find non existent POA" << std::endl;
-      find_non_existant_POA (root_poa, "thirdPOA", false);
+      find_non_existent_POA (root_poa, "thirdPOA", false);
 
       _orb->destroy();
     }

--- a/tests/poa/forwarding/README
+++ b/tests/poa/forwarding/README
@@ -32,5 +32,5 @@ Check run_test.pl for an example of how to run the server.
 The first three calls will be called on the first server, then the
 location forwarding is called and the next three calls are going to be
 called on the second server.  Location forwarding is then called on
-the second one and the last three calls are then done on the thrid
+the second one and the last three calls are then done on the third
 server.

--- a/tests/poa/generic_servant/client.cpp
+++ b/tests/poa/generic_servant/client.cpp
@@ -107,7 +107,7 @@ print_stats(ACE_Profile_Timer::ACE_Elapsed_Time &elapsed_time,
     return true;
   } else
   {
-    TAOX11_TEST_ERROR << "\tNo time stats printed. Zero iterations or error ocurred."
+    TAOX11_TEST_ERROR << "\tNo time stats printed. Zero iterations or error occurred."
         << std::endl;
     return false;
   }

--- a/tests/wstring/tao/testdata.h
+++ b/tests/wstring/tao/testdata.h
@@ -34,7 +34,7 @@ CORBA::WStringSeq * Array2Seq(const std::wstring arr[])
 // Test if wstring sequence content is equal.
 bool eqv(const CORBA::WStringSeq& v1, CORBA::WStringSeq& v2)
 {
-  //if (v1.length() != v2.lenght())
+  //if (v1.length() != v2.length())
   //  return false;
   for (CORBA::WStringSeq::size_type ix = 0; ix < v1.length(); ix++)
   {


### PR DESCRIPTION
    * brix/taox11/docs/generate_client.rd:
    * tao/x11/dynamic_any/dynvalue_i.cpp:
    * tao/x11/ifr_client_adapter.cpp:
    * tao/x11/logger/logstream_t.h:
    * tests/ami_test/ami/client.cpp:
    * tests/ami_test/ami/tao/client.cpp:
    * tests/ami_test/ami_collocation/collocation_tester.cpp:
    * tests/ami_test/ami_in_out_inout/client.cpp:
    * tests/ami_test/ami_naming/client.cpp:
    * tests/ami_test/annotations/client.cpp:
    * tests/ami_test/attr_raises/client.cpp:
    * tests/ami_test/derived/client.cpp:
    * tests/ami_test/exceptions/client.cpp:
    * tests/ami_test/keywords/client.cpp:
    * tests/ami_test/keywords/keywords.doxygen:
    * tests/ami_test/mix_ami_noami/client.cpp:
    * tests/ami_test/mix_annotation_pragma/client.cpp:
    * tests/ami_test/multi_idl_mix_2client/client2.cpp:
    * tests/ami_test/multiple_idl_ami/client.cpp:
    * tests/ami_test/multiple_idl_derived/client.cpp:
    * tests/ami_test/multiple_idl_derived_gca/client.cpp:
    * tests/ami_test/multiple_idl_mix/client.cpp:
    * tests/ami_test/multiple_idl_mix_gca/client.cpp:
    * tests/ami_test/multiple_inherit/client.cpp:
    * tests/ami_test/no_module/client.cpp:
    * tests/ami_test/replyhandler/client.cpp:
    * tests/ami_test/use_of_gca/client.cpp:
    * tests/ami_test/weak_ref/client.cpp:
    * tests/idl_test/idl_test.mpc:
    * tests/idl_test/main.cpp:
    * tests/poa/children/children.cpp:
    * tests/poa/findpoa/findpoa.cpp:
    * tests/poa/forwarding/README:
    * tests/poa/generic_servant/client.cpp:
    * tests/wstring/tao/testdata.h: