### PR TITLE
Do not use parentheses for method calls with no arguments, fixed by r…

### DIFF
--- a/ridlbe/base/visitorbase.rb
+++ b/ridlbe/base/visitorbase.rb
@@ -394,7 +394,7 @@ module IDL
       end
 
       def has_annotations?
-        !@node.annotations().empty?
+        !@node.annotations.empty?
       end
 
       def annotations

--- a/ridlbe/base/writerbase.rb
+++ b/ridlbe/base/writerbase.rb
@@ -382,7 +382,7 @@ module IDL
         if _cur_scope
           @properties[:_context][:scopes] = _scopes_bak
           @properties[:_context][:cur_scope] = _scopes_bak.last
-          println()
+          println
           printiln('// leaving Base::CodeWriter#at_global_scope')
           @properties[:_context][:scopes].each do |_scope|
             write_open_scope(_scope)

--- a/ridlbe/c++11/writers/amistubheader.rb
+++ b/ridlbe/c++11/writers/amistubheader.rb
@@ -110,7 +110,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from AmiStubHeaderWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -120,7 +120,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
@@ -138,7 +138,7 @@ module IDL
 
       def enter_interface(node)
         return if !needs_ami_generation?(node)
-        println()
+        println
         printiln('// generated from AmiStubHeaderWriter#enter_interface')
         sn = node.scoped_cxxname
         #use ami_interface for ReplyHandler
@@ -331,7 +331,7 @@ module IDL
       end
 
       def pre_visit(parser)
-        println()
+        println
         printiln('// generated from AmiStubHeaderTraitsWriter#pre_visit')
         printiln('namespace TAOX11_NAMESPACE')
         printiln('{')
@@ -442,7 +442,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from AmiStubHeaderAmiCWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -452,7 +452,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
@@ -468,7 +468,7 @@ module IDL
 
       def enter_interface(node)
         return if !needs_ami_generation?(node)
-        println()
+        println
         printiln('// generated from AmiStubHeaderAmiCWriter#enter_interface')
         sn = node.scoped_cxxname
         unless @fwd_decl_cache.has_key?(sn)
@@ -509,7 +509,7 @@ module IDL
       end
 
       def pre_visit(parser)
-        println()
+        println
         printiln('// generated from AmiStubHeaderAmicTraitsWriter#pre_visit')
         printiln('namespace TAOX11_NAMESPACE')
         printiln('{')
@@ -548,7 +548,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from AmiStubHeaderSrvWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -558,7 +558,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
@@ -598,7 +598,7 @@ module IDL
       end
 
       def pre_visit(parser)
-        println()
+        println
         printiln('// generated from AmiStubHeaderSrvTraitsWriter#pre_visit')
         printiln('namespace TAOX11_NAMESPACE {')
         inc_nest

--- a/ridlbe/c++11/writers/amistubproxy.rb
+++ b/ridlbe/c++11/writers/amistubproxy.rb
@@ -63,7 +63,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from AmiStubProxyWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -73,14 +73,14 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
       def enter_interface(node)
         super
         return if !needs_ami_generation?(node)
-        println()
+        println
         printiln('// generated from AmiStubProxyWriter#enter_interface')
         ami_handler_interface_with_ami_inheritance.visit_pre(node)
         inc_nest
@@ -343,7 +343,7 @@ module IDL
        end
 
        def pre_visit(parser)
-         println()
+         println
          printiln('// generated from AmiStubProxyObjRefTraitsWriter#pre_visit')
        end
 
@@ -441,7 +441,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from AmiStubProxySrvWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -451,14 +451,14 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
       def enter_interface(node)
         return if !needs_ami_generation?(node)
         super
-        println()
+        println
         printiln('// generated from AmiStubProxySrvWriter#enter_interface')
         printiln('namespace POA {')
         inc_nest
@@ -472,7 +472,7 @@ module IDL
         ami_handler_interface.visit_post(node)
         dec_nest
         printiln("} // namespace POA")
-        println()
+        println
         super
       end
      end # AmiStubProxySrvWriter

--- a/ridlbe/c++11/writers/amistubsource.rb
+++ b/ridlbe/c++11/writers/amistubsource.rb
@@ -138,7 +138,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from AmiStubSourceWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -148,7 +148,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
@@ -455,7 +455,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from AmiStubProxySourceWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -465,7 +465,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
@@ -481,7 +481,7 @@ module IDL
           end
         end
         intf.visit_proxy(node)
-        println()
+        println
       end
 
     end # AmiStubProxySourceWriter
@@ -492,12 +492,12 @@ module IDL
       end
 
       def pre_visit(parser)
-        println()
+        println
         printiln('// generated from StubSourceObjTraitsWriter#pre_visit')
         printiln('namespace TAOX11_NAMESPACE')
         printiln('{')
         inc_nest
-        println()
+        println
         printiln('namespace CORBA')
         printiln('{')
         inc_nest
@@ -506,7 +506,7 @@ module IDL
       def post_visit(parser)
         dec_nest
         printiln('} // namespace CORBA')
-        println()
+        println
         dec_nest
         printiln('} // namespace TAOX11_NAMESPACE')
       end
@@ -525,7 +525,7 @@ module IDL
        end
 
        def pre_visit(parser)
-         println()
+         println
          printiln('// generated from AmiStubSourceProxyObjRefTraitsWriter#pre_visit')
        end
 
@@ -680,7 +680,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from AmiStubSourceAmiCWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -690,7 +690,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
@@ -737,7 +737,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from AmiStubSourceSrvWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -747,14 +747,14 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
       def enter_interface(node)
         return if !needs_ami_generation?(node)
         super
-        println()
+        println
         printiln('// generated from AmiStubSourceSrvWriter#enter_interface')
         printiln('namespace POA {')
         inc_nest
@@ -780,7 +780,7 @@ module IDL
             v.visit_attribute(_att)
           end
         end
-        println()
+        println
         intf = ami_handler_interface_with_ami_inheritance
         ###
         # Overload for this visitor only
@@ -792,7 +792,7 @@ module IDL
         intf.visit_skel(node)
         dec_nest
         printiln("} // namespace POA")
-        println()
+        println
         super
       end
 
@@ -813,7 +813,7 @@ module IDL
         println
         printiln('// generated from AmiStubSourceSArgTraitsWriter#pre_visit')
         println('namespace TAOX11_NAMESPACE {')
-        gen_exceptionholder_traits()
+        gen_exceptionholder_traits
       end
 
       def post_visit(parser)
@@ -884,7 +884,7 @@ module IDL
       end
 
       def gen_exceptionholder_traits()
-        visitor(ExceptionVisitor).visit_exception_holder()
+        visitor(ExceptionVisitor).visit_exception_holder
       end
 
     end # AmiStubSourceSArgTraitsWriter

--- a/ridlbe/c++11/writers/impl_header.rb
+++ b/ridlbe/c++11/writers/impl_header.rb
@@ -49,7 +49,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from ImplHeaderWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -59,7 +59,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 

--- a/ridlbe/c++11/writers/impl_source.rb
+++ b/ridlbe/c++11/writers/impl_source.rb
@@ -38,7 +38,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from ImplSourceWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -48,7 +48,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
@@ -58,7 +58,7 @@ module IDL
         if node.is_local? || node.is_pseudo?
         else
           if generate_servant_implementation?
-            println()
+            println
             printiln('// generated from ImplSourceWriter#enter_interface')
             visitor(InterfaceVisitor).visit_pre(node)
             inc_nest
@@ -81,7 +81,7 @@ module IDL
               visitor(AttributeVisitor) { |v| v.interface(node); v.visit_attribute(_att) }
             end
             visitor(InterfaceVisitor).visit_post(node)
-            println()
+            println
           end
         end
         super

--- a/ridlbe/c++11/writers/servantheader.rb
+++ b/ridlbe/c++11/writers/servantheader.rb
@@ -59,7 +59,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from ServantHeaderWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -69,7 +69,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
@@ -147,7 +147,7 @@ module IDL
       end
 
       def pre_visit(parser)
-        println()
+        println
         printiln('// generated from ServantHeaderSrvTraitsWriter#pre_visit')
         printiln('namespace TAOX11_NAMESPACE {')
         inc_nest
@@ -183,7 +183,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from ServantHeaderTieWriter#pre_visit')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -193,7 +193,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 

--- a/ridlbe/c++11/writers/servantproxy.rb
+++ b/ridlbe/c++11/writers/servantproxy.rb
@@ -55,7 +55,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from ServantProxyWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -65,14 +65,14 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
       def enter_interface(node)
         return if node.is_local? || node.is_pseudo? || node.is_abstract?
         super
-        println()
+        println
         printiln('// generated from ServantProxyWriter#enter_interface')
         printiln('namespace POA {')
         inc_nest
@@ -85,7 +85,7 @@ module IDL
         visitor(InterfaceVisitor).visit_post(node)
         dec_nest
         printiln("} // namespace POA")
-        println()
+        println
         super
       end
     end # ServantProxyWriter

--- a/ridlbe/c++11/writers/servantsource.rb
+++ b/ridlbe/c++11/writers/servantsource.rb
@@ -62,7 +62,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from ServantSourceWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -72,14 +72,14 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
       def enter_interface(node)
         return if node.is_local? || node.is_pseudo? || node.is_abstract?
         super
-        println()
+        println
         printiln('// generated from ServantSourceWriter#enter_interface')
         printiln('namespace POA')
         printiln('{')
@@ -98,11 +98,11 @@ module IDL
         node.attributes(true).each do |_att|
           visitor(AttributeVisitor) { |v| v.interface(node); v.visit_attribute(_att) }
         end
-        println()
+        println
         visitor(InterfaceVisitor).visit_skel(node)
         dec_nest
         printiln("} // namespace POA")
-        println()
+        println
         super
       end
 

--- a/ridlbe/c++11/writers/stubheader.rb
+++ b/ridlbe/c++11/writers/stubheader.rb
@@ -91,7 +91,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from StubHeaderWriter#enter_module')
         printiln("/// @copydoc #{self.doc_scoped_name node}")
         printiln('namespace ' + node.cxxname)
@@ -102,7 +102,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
@@ -116,7 +116,7 @@ module IDL
         end unless params[:no_object_traits]
       end
       def enter_interface(node)
-        println()
+        println
         printiln('// generated from StubHeaderWriter#enter_interface')
         sn = node.scoped_cxxname
         unless @fwd_decl_cache.has_key?(sn)
@@ -239,7 +239,7 @@ module IDL
       end
 
       def visit_const(node)
-        println()
+        println
         printiln('// generated from StubHeaderWriter#visit_const')
         printiln("/// @copydoc #{self.doc_scoped_name node}")
         case node.expression.idltype
@@ -444,7 +444,7 @@ module IDL
       end
 
       def pre_visit(parser)
-        println()
+        println
         printiln('// generated from StubHeaderIDLTraitsWriter#pre_visit')
         printiln('namespace TAOX11_NAMESPACE')
         println('{')
@@ -528,7 +528,7 @@ module IDL
       end
 
       def pre_visit(parser)
-        println()
+        println
         printiln('// generated from StubHeaderIDLTraitsDefWriter#pre_visit')
         printiln('namespace TAOX11_NAMESPACE')
         println('{')

--- a/ridlbe/c++11/writers/stubproxy.rb
+++ b/ridlbe/c++11/writers/stubproxy.rb
@@ -57,7 +57,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from StubProxyWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -67,14 +67,14 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
       def enter_interface(node)
         super
         return if node.is_local? || node.is_pseudo? || node.is_abstract?
-        println()
+        println
         printiln('// generated from StubProxyWriter#enter_interface')
         visitor(InterfaceVisitor).visit_pre(node)
         inc_nest
@@ -364,7 +364,7 @@ module IDL
        end
 
        def pre_visit(parser)
-         println()
+         println
          printiln('// generated from StubProxyObjRefTraitsWriter#pre_visit')
        end
 

--- a/ridlbe/c++11/writers/stubsource.rb
+++ b/ridlbe/c++11/writers/stubsource.rb
@@ -73,15 +73,15 @@ module IDL
         unless node.enclosure.is_a?(IDL::AST::Module)
           case node.idltype.resolved_type
           when IDL::Type::Fixed
-            println()
+            println
             printiln('// generated from StubSourceWriter#visit_const')
-            printi("const #{node.idltype.cxx_type()} ")
+            printi("const #{node.idltype.cxx_type} ")
             println(node.enclosure.cxxname+'::'+node.cxxname + ' {"' + expression_to_s(node.expression, node.enclosure) + '"};')
           end
           if [Type::String, Type::WString].include?(node.expression.idltype.class)
-            println()
+            println
             printiln('// generated from StubSourceWriter#visit_const')
-            printi("const #{node.idltype.cxx_type()} ")
+            printi("const #{node.idltype.cxx_type} ")
             println(node.enclosure.cxxname+'::'+node.cxxname + ' {' + expression_to_s(node.expression, node.enclosure) + '};')
           end
         end
@@ -89,7 +89,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from StubSourceWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -99,7 +99,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
@@ -385,7 +385,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from StubProxySourceWriter#enter_module')
         printiln('namespace ' + node.cxxname)
         printiln('{')
@@ -395,7 +395,7 @@ module IDL
       def leave_module(node)
         dec_nest
         printiln("} // namespace #{node.cxxname}")
-        println()
+        println
         super
       end
 
@@ -403,7 +403,7 @@ module IDL
         super
         return if node.is_local? || node.is_pseudo? || node.is_abstract?
         visitor(InterfaceVisitor).visit_proxy(node)
-        println()
+        println
       end
 
     end # StubProxySourceWriter
@@ -414,12 +414,12 @@ module IDL
       end
 
       def pre_visit(parser)
-        println()
+        println
         printiln('// generated from StubSourceObjTraitsWriter#pre_visit')
         printiln('namespace TAOX11_NAMESPACE')
         printiln('{')
         inc_nest
-        println()
+        println
         printiln('namespace CORBA')
         printiln('{')
         inc_nest
@@ -428,7 +428,7 @@ module IDL
       def post_visit(parser)
         dec_nest
         printiln('} // namespace CORBA')
-        println()
+        println
         dec_nest
         printiln('} // namespace TAOX11_NAMESPACE')
       end
@@ -452,7 +452,7 @@ module IDL
       end
 
       def pre_visit(parser)
-        println()
+        println
         printiln('// generated from StubSourceProxyObjRefTraitsWriter#pre_visit')
       end
 


### PR DESCRIPTION
…ubocop

    * ridlbe/base/visitorbase.rb:
    * ridlbe/base/writerbase.rb:
    * ridlbe/c++11/writers/amistubheader.rb:
    * ridlbe/c++11/writers/amistubproxy.rb:
    * ridlbe/c++11/writers/amistubsource.rb:
    * ridlbe/c++11/writers/impl_header.rb:
    * ridlbe/c++11/writers/impl_source.rb:
    * ridlbe/c++11/writers/servantheader.rb:
    * ridlbe/c++11/writers/servantproxy.rb:
    * ridlbe/c++11/writers/servantsource.rb:
    * ridlbe/c++11/writers/stubheader.rb:
    * ridlbe/c++11/writers/stubproxy.rb:
    * ridlbe/c++11/writers/stubsource.rb: