### PR TITLE
Removed redundant whitespace

### DIFF
--- a/examples/ami/test_i.h
+++ b/examples/ami/test_i.h
@@ -14,7 +14,7 @@
 #include "testS.h"
 
 class A_i
-: public virtual CORBA::servant_traits< Test::A>::base_type
+: public virtual CORBA::servant_traits<Test::A>::base_type
 {
 public:
   /// ctor

--- a/ridlbe/c++11/templates/cli/src/array_typecode.erb
+++ b/ridlbe/c++11/templates/cli/src/array_typecode.erb
@@ -1,7 +1,7 @@
 
 // generated from <%= ridl_template_path %>
 % cxxdim_sizes.reverse.each_with_index do |sz, ix|
-static TAO_TAO::TypeCode::Sequence< TAO_CORBA::TypeCode_ptr const *,
+static TAO_TAO::TypeCode::Sequence<TAO_CORBA::TypeCode_ptr const *,
   TAO_TAO::Null_RefCount_Policy>
     _tao<%= cxx_typecode %>_arytc_<%= ix %> (
       TAO_CORBA::tk_array,

--- a/ridlbe/c++11/templates/cli/src/sequence_typecode.erb
+++ b/ridlbe/c++11/templates/cli/src/sequence_typecode.erb
@@ -1,6 +1,6 @@
 
 // generated from <%= ridl_template_path %>
-static TAO_TAO::TypeCode::Sequence< TAO_CORBA::TypeCode_ptr const *,
+static TAO_TAO::TypeCode::Sequence<TAO_CORBA::TypeCode_ptr const *,
   TAO_TAO::Null_RefCount_Policy>
     _tao<%= cxx_typecode %>_seqtc (
       TAO_CORBA::tk_sequence,

--- a/ridlbe/c++11/templates/cli/src/string_typecode.erb
+++ b/ridlbe/c++11/templates/cli/src/string_typecode.erb
@@ -1,6 +1,6 @@
 
 // generated from <%= ridl_template_path %>
-static TAO_TAO::TypeCode::String< TAO_TAO::Null_RefCount_Policy>
+static TAO_TAO::TypeCode::String<TAO_TAO::Null_RefCount_Policy>
     _tao<%= cxx_typecode %>_str (
       TAO_CORBA::<% if is_wstring? %>tk_wstring<% else %>tk_string<% end %>,
       <%= bound %>U);

--- a/ridlbe/c++11/templates/cli/src/union_typecode.erb
+++ b/ridlbe/c++11/templates/cli/src/union_typecode.erb
@@ -4,7 +4,7 @@
 % case_lst << [default_member, default_label] if has_default? && !has_implicit_default?
 % case_lst.each_with_index do |(m, lbl), nr|
 %   tc = m.is_standard_typecode? ? "TAO_CORBA::#{m.cxx_typecode}" : "__tao::#{m.scoped_cxx_typecode}"
-static ::TAOX11_NAMESPACE::TypeCode::Case_T< <%= scoped_switch_cxxtype %>,
+static ::TAOX11_NAMESPACE::TypeCode::Case_T<<%= scoped_switch_cxxtype %>,
   char const *,
   TAO_CORBA::TypeCode_ptr const *> const
     _tao_cases<%= cxx_typecode %>_<%= nr %> (


### PR DESCRIPTION
    * examples/ami/test_i.h:
    * ridlbe/c++11/templates/cli/src/array_typecode.erb:
    * ridlbe/c++11/templates/cli/src/sequence_typecode.erb:
    * ridlbe/c++11/templates/cli/src/string_typecode.erb: