### PR TITLE
Log more system/compiler information as part of our startup logging

### DIFF
--- a/tao/x11/orb.cpp
+++ b/tao/x11/orb.cpp
@@ -37,6 +37,8 @@
     __DATE__ " " __TIME__
 #endif
 
+#include "ace/OS_NS_sys_utsname.h"
+
 TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 
 /// @name CDR streaming operator specializations for TAOX11_CORBA::ORB::InvalidName
@@ -835,7 +837,13 @@ namespace TAOX11_NAMESPACE
                                  << (uint32_t)TAOX11_MINOR_VERSION << '.'
                                  << (uint32_t)TAOX11_MICRO_VERSION
                                  << " (c) Remedy IT");
-      TAOX11_LOG_INFO ("Buildstamp : " << TAOX11_RELEASE_BUILDSTAMP);
+      ACE_utsname uname;
+      ACE_OS::uname (&uname);
+      TAOX11_LOG_INFO ("TAOX11 machine: " << uname.nodename << ", " << uname.machine);
+      TAOX11_LOG_INFO ("TAOX11 platform: " << uname.sysname << ", " <<  uname.release << ", " << uname.version);
+      TAOX11_LOG_INFO ("TAOX11 compiler: " << ACE::compiler_name() << " version "
+                                           << ACE::compiler_major_version() << "." << ACE::compiler_minor_version () << "." << ACE::compiler_beta_version ());
+      TAOX11_LOG_INFO ("TAOX11 buildstamp: " << TAOX11_RELEASE_BUILDSTAMP);
 
       try {
         TAO_CORBA::ORB_var _orb;

--- a/tao/x11/orb.cpp
+++ b/tao/x11/orb.cpp
@@ -838,9 +838,12 @@ namespace TAOX11_NAMESPACE
                                  << (uint32_t)TAOX11_MICRO_VERSION
                                  << " (c) Remedy IT");
       ACE_utsname uname;
-      ACE_OS::uname (&uname);
-      TAOX11_LOG_INFO ("TAOX11 machine: " << uname.nodename << ", " << uname.machine);
-      TAOX11_LOG_INFO ("TAOX11 platform: " << uname.sysname << ", " <<  uname.release << ", " << uname.version);
+      int const result = ACE_OS::uname (&uname);
+      if (result != -1)
+      {
+        TAOX11_LOG_INFO ("TAOX11 machine: " << uname.nodename << ", " << uname.machine);
+        TAOX11_LOG_INFO ("TAOX11 platform: " << uname.sysname << ", " <<  uname.release << ", " << uname.version);
+      }
       TAOX11_LOG_INFO ("TAOX11 compiler: " << ACE::compiler_name() << " version "
                                            << ACE::compiler_major_version() << "." << ACE::compiler_minor_version () << "." << ACE::compiler_beta_version ());
       TAOX11_LOG_INFO ("TAOX11 buildstamp: " << TAOX11_RELEASE_BUILDSTAMP);


### PR DESCRIPTION
Gives for example on my system
```
TAOX11      [LP_INFO]     - (19946|139915464712704) - 20:08:02.981786 - TAOX11 1.8.1 (c) Remedy IT
TAOX11      [LP_INFO]     - (19946|139915464712704) - 20:08:02.981837 - TAOX11 machine: jw5401, x86_64
TAOX11      [LP_INFO]     - (19946|139915464712704) - 20:08:02.981842 - TAOX11 platform: Linux, 5.16.4-1-default, #1 SMP PREEMPT Sat Jan 29 12:57:02 UTC 2022 (b146677)
TAOX11      [LP_INFO]     - (19946|139915464712704) - 20:08:02.981848 - TAOX11 compiler: g++ version 11.2.0
TAOX11      [LP_INFO]     - (19946|139915464712704) - 20:08:02.981852 - TAOX11 buildstamp: Mar 31 2022 20:07:58
```