### PR TITLE
Made the template a little bit smarter to only generate the zero init…

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -62,7 +62,7 @@ private:
   union u_type_
   {
 // Compilation with c++11 standard gives errors on  the ' = default' declaration
-#if (!defined(ACE_HAS_CPP14) || (defined (_MSC_VER) && (_MSC_VER < 1930)))
+#if !defined (ACE_HAS_CPP14) || (defined (_MSC_VER) && (_MSC_VER < 1930))
     u_type_ ();
 #else
     u_type_ () = default;
@@ -72,11 +72,15 @@ private:
 % # The default member or the first member should use the zero_initializer
 % # Visual Studio 2019 doesn't seem to like using default, this leads to
 % # an internal compiler error, see SW331
-#if (!defined(ACE_HAS_CPP14) || (defined (_MSC_VER) && (_MSC_VER < 1930)))
+% if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
+#if !defined (ACE_HAS_CPP14) || (defined (_MSC_VER) && (_MSC_VER < 1930))
     <%= _m.cxx_member_type %> <%= _m.cxxname %>_;
 #else
     <%= _m.cxx_member_type %> <%= _m.cxxname %>_<% if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first) %> <%= _m.zero_initializer %><% end %>;
 #endif
+% else
+    <%= _m.cxx_member_type %> <%= _m.cxxname %>_;
+% end
 % end
   } u_ {};
 }; // class <%= cxxname %>


### PR DESCRIPTION
…ializer for the default or first member, reduces the amount of code generated with a union with multiple members

    * ridlbe/c++11/templates/cli/hdr/union_post.erb: