### PR TITLE
Make use of noexcept and override for the generated default destructo…

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/except_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/except_post.erb
@@ -1,7 +1,7 @@
 
   // generated from <%= ridl_template_path %>
   <%= cxxname %> ();
-  ~<%= cxxname %> () throw () override = default;
+  ~<%= cxxname %> () noexcept override = default;
   <%= cxxname %> (const <%= cxxname %>&) = default;
   <%= cxxname %> (<%= cxxname %>&&) = default;
 % if member_count > 0

--- a/tao/x11/PolicyC.cpp
+++ b/tao/x11/PolicyC.cpp
@@ -35,10 +35,6 @@ namespace TAOX11_NAMESPACE {
   namespace CORBA {
 
     // generated from c++/cli_src/except_src.erb
-    TAOX11_CORBA::PolicyError::~PolicyError () throw ()
-    {
-    }
-
     const char* TAOX11_CORBA::PolicyError::what() const noexcept
     {
       return "TAOX11_CORBA::PolicyError";
@@ -80,10 +76,6 @@ namespace TAOX11_NAMESPACE {
     }
 
     // generated from c++/cli_src/except_src.erb
-    TAOX11_CORBA::InvalidPolicies::~InvalidPolicies () throw ()
-    {
-    }
-
     const char* TAOX11_CORBA::InvalidPolicies::what() const noexcept
     {
       return "TAOX11_CORBA::InvalidPolicies";

--- a/tao/x11/PolicyC.h
+++ b/tao/x11/PolicyC.h
@@ -84,7 +84,7 @@ namespace TAOX11_NAMESPACE {
 
       // generated from c++/cli_hdr/except_post.erb
       PolicyError ();
-      virtual ~PolicyError () throw ();
+      ~PolicyError () noexcept override = default;
       PolicyError (const PolicyError&) = default;
       PolicyError (PolicyError&&) = default;
       explicit PolicyError (TAOX11_CORBA::PolicyErrorCode reason);
@@ -122,7 +122,7 @@ namespace TAOX11_NAMESPACE {
 
       // generated from c++/cli_hdr/except_post.erb
       InvalidPolicies ();
-      virtual ~InvalidPolicies () throw ();
+      ~InvalidPolicies () noexcept override = default;
       InvalidPolicies (const InvalidPolicies&) = default;
       InvalidPolicies (InvalidPolicies&&) = default;
       explicit InvalidPolicies (TAOX11_CORBA::UShortSeq indices);

--- a/tao/x11/anytypecode/typecode.h
+++ b/tao/x11/anytypecode/typecode.h
@@ -59,7 +59,7 @@ namespace TAOX11_NAMESPACE
         TAOX11_NAMESPACE::CORBA::Exception *_tao_duplicate () const override;
 
         Bounds ();
-        virtual ~Bounds () throw ();
+        ~Bounds () noexcept override = default;
         Bounds (const Bounds&) = default;
         Bounds (Bounds&&) = default;
         Bounds& operator= (const Bounds& x);
@@ -84,7 +84,7 @@ namespace TAOX11_NAMESPACE
           TAOX11_NAMESPACE::CORBA::Exception *_tao_duplicate () const override;
 
           BadKind ();
-          virtual ~BadKind () throw ();
+          ~BadKind () noexcept override = default;
           BadKind (const BadKind&) = default;
           BadKind (BadKind&&) = default;
           BadKind& operator= (const BadKind& x);

--- a/tao/x11/anytypecode/typecode_impl.cpp
+++ b/tao/x11/anytypecode/typecode_impl.cpp
@@ -479,10 +479,6 @@ TAOX11_NAMESPACE::CORBA::typecode_reference const TAOX11_NAMESPACE::CORBA::TypeC
     __tao::TAOX11_NAMESPACE::CORBA::TypeCode::_tc_BadKind, true);
 
 
-TAOX11_NAMESPACE::CORBA::TypeCode::Bounds::~Bounds () throw ()
-{
-}
-
 void
 TAOX11_NAMESPACE::CORBA::TypeCode::Bounds::_info (std::ostream& user_exception_info) const
 {
@@ -517,10 +513,6 @@ TAOX11_NAMESPACE::CORBA::Exception *TAOX11_NAMESPACE::CORBA::TypeCode::Bounds::_
   if (!result)
     throw TAO_CORBA::NO_MEMORY ();
   return result;
-}
-
-TAOX11_NAMESPACE::CORBA::TypeCode::BadKind::~BadKind () throw ()
-{
 }
 
 void

--- a/tao/x11/exception.h
+++ b/tao/x11/exception.h
@@ -41,7 +41,7 @@ namespace TAOX11_NAMESPACE
     {
     public:
       /// Destructor.
-      virtual ~Exception () throw () = default;
+      ~Exception () noexcept override = default;
 
       const char* what() const noexcept override;
 

--- a/tao/x11/orb.cpp
+++ b/tao/x11/orb.cpp
@@ -62,10 +62,6 @@ namespace TAOX11_NAMESPACE
    */
   namespace CORBA
   {
-    ORB::InvalidName::~InvalidName () throw ()
-    {
-    }
-
     void
     ORB::InvalidName::_info (std::ostream& user_exception_info) const
     {

--- a/tao/x11/orb.h
+++ b/tao/x11/orb.h
@@ -131,7 +131,7 @@ namespace TAOX11_NAMESPACE
         CORBA::Exception *_tao_duplicate () const override;
 
         InvalidName ();
-        virtual ~InvalidName () throw ();
+        ~InvalidName () noexcept override = default;
         InvalidName (const InvalidName&) = default;
         InvalidName (InvalidName&&) = default;
         InvalidName& operator= (const InvalidName& x) = default;

--- a/tao/x11/system_exception.h
+++ b/tao/x11/system_exception.h
@@ -35,7 +35,7 @@ namespace TAOX11_NAMESPACE
     {
     public:
       /// Destructor.
-      virtual ~SystemException () throw() = default;
+      ~SystemException () noexcept override = default;
 
       /// Get the minor status.
       uint32_t minor () const
@@ -198,10 +198,9 @@ namespace TAOX11_NAMESPACE
     class TAOX11_Export name final : public SystemException \
     { \
     public: \
-      virtual ~name () throw () = default; \
+      ~name () noexcept override = default; \
       name (); \
-      name (uint32_t code, \
-            CORBA::CompletionStatus completed); \
+      name (uint32_t code, CORBA::CompletionStatus completed); \
       name (const name &) = default; \
       name (name &&) = default; \
       name & operator = (const name &) = default; \

--- a/tao/x11/user_exception.h
+++ b/tao/x11/user_exception.h
@@ -19,7 +19,7 @@ namespace TAOX11_NAMESPACE {
     {
     public:
       /// Destructor.
-      virtual ~UserException () throw() = default;
+      ~UserException () noexcept override = default;
 
       /// noop
       void _tao_encode (TAO_OutputCDR &) const override;


### PR DESCRIPTION
…rs for our exception classes

    * ridlbe/c++11/templates/cli/hdr/except_post.erb:
    * tao/x11/PolicyC.cpp:
    * tao/x11/PolicyC.h:
    * tao/x11/anytypecode/typecode.h:
    * tao/x11/anytypecode/typecode_impl.cpp:
    * tao/x11/exception.h:
    * tao/x11/orb.cpp:
    * tao/x11/orb.h:
    * tao/x11/system_exception.h:
    * tao/x11/user_exception.h: