### PR TITLE
Reduced amount of lines in traits generation

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_traits.erb
@@ -5,9 +5,7 @@ namespace IDL
   template <typename OStrm_>
   struct formatter<<%= amic_scoped_cxxtype %>, OStrm_>
   {
-    inline OStrm_& operator ()(
-        OStrm_& os_,
-        <%= amic_scoped_cxx_in_type %> val_)
+    inline OStrm_& operator ()(OStrm_& os_, <%= amic_scoped_cxx_in_type %> val_)
     {
       os_ << IDL::traits<TAOX11_CORBA::Object>::_dump (std::move (val_), "<%= formatted_cxxname %>", true);
       return os_;
@@ -15,9 +13,7 @@ namespace IDL
   };
 
   template <typename OStrm_, typename Fmt>
-  inline OStrm_& operator <<(
-      OStrm_& os,
-      TAOX11_CORBA::amic_traits <<%= scoped_cxxtype %>>::__Writer<Fmt> w)
+  inline OStrm_& operator <<(OStrm_& os, TAOX11_CORBA::amic_traits <<%= scoped_cxxtype %>>::__Writer<Fmt> w)
   {
     using writer_t = TAOX11_CORBA::amic_traits <<%= scoped_cxxtype %>>::__Writer<Fmt>;
     using formatter_t = typename std::conditional<
@@ -26,8 +22,6 @@ namespace IDL
                             std::false_type>::value,
                           IDL::formatter<<%= amic_scoped_cxxtype %>, OStrm_>,
                           typename writer_t::formatter_t>::type;
-    return TAOX11_CORBA::amic_traits <<%= scoped_cxxtype %>>::write_on (
-        os, w.val_,
-        formatter_t ());
+    return TAOX11_CORBA::amic_traits <<%= scoped_cxxtype %>>::write_on (os, w.val_, formatter_t ());
   }
 } // namespace IDL

--- a/ridlbe/c++11/templates/cli/hdr/enum_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/enum_idl_traits.erb
@@ -5,9 +5,7 @@ struct traits <<%= scoped_cxxtype %>>
   : IDL::common_byval_traits<<%= scoped_cxxtype %>>
 {
   template <typename OStrm_, typename Formatter = formatter<value_type, OStrm_>>
-  static inline OStrm_& write_on(
-      OStrm_& os_, in_type val_,
-      Formatter fmt_ = Formatter ())
+  static inline OStrm_& write_on(OStrm_& os_, in_type val_, Formatter fmt_ = Formatter ())
   {
     return fmt_ (os_, val_);
   }
@@ -19,9 +17,7 @@ struct traits <<%= scoped_cxxtype %>>
 template <typename OStrm_>
 struct formatter<<%= scoped_cxxtype %>, OStrm_>
 {
-  inline OStrm_& operator ()(
-      OStrm_& os_,
-      <%= scoped_cxx_in_type %> val_)
+  inline OStrm_& operator ()(OStrm_& os_, <%= scoped_cxx_in_type %> val_)
   {
     switch (val_)
     {
@@ -34,9 +30,7 @@ struct formatter<<%= scoped_cxxtype %>, OStrm_>
 };
 
 template <typename OStrm_, typename Fmt>
-inline OStrm_& operator <<(
-    OStrm_& os,
-    IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt> w)
+inline OStrm_& operator <<(OStrm_& os, IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
   using writer_t = IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt>;
   using formatter_t = typename std::conditional<
@@ -45,7 +39,5 @@ inline OStrm_& operator <<(
                           std::false_type>::value,
                         formatter<<%= scoped_cxxtype %>, OStrm_>,
                         typename writer_t::formatter_t>::type;
-  return IDL::traits<<%= scoped_cxxtype %>>::write_on (
-      os, w.val_,
-      formatter_t ());
+  return IDL::traits<<%= scoped_cxxtype %>>::write_on (os, w.val_, formatter_t ());
 }

--- a/ridlbe/c++11/templates/cli/hdr/fixed_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/fixed_idl_traits.erb
@@ -14,9 +14,7 @@ struct traits <<%= scoped_cxxtype %>>
   using scale = std::integral_constant< uint16_t, <%= scale %>>;
 
   template <typename OStrm_, typename Formatter = formatter<value_type, OStrm_>>
-  static inline OStrm_& write_on(
-      OStrm_& os_, in_type val_,
-      Formatter fmt_ = Formatter ())
+  static inline OStrm_& write_on(OStrm_& os_, in_type val_, Formatter fmt_ = Formatter ())
   {
     return fmt_ (os_, val_);
   }
@@ -28,12 +26,9 @@ struct traits <<%= scoped_cxxtype %>>
 template <typename OStrm_>
 struct formatter<<%= scoped_cxxtype %>, OStrm_>
 {
-  inline OStrm_& operator ()(
-      OStrm_& os_,
-      <%= scoped_cxx_in_type %> val_)
+  inline OStrm_& operator ()(OStrm_& os_, <%= scoped_cxx_in_type %> val_)
   {
-    os_ << "<%= formatted_cxxtype %> "
-        << val_.to_string ();
+    os_ << "<%= formatted_cxxtype %> " << val_.to_string ();
     return os_;
   }
 };
@@ -50,9 +45,7 @@ inline OStrm_& operator <<(
                           std::false_type>::value,
                         formatter<<%= scoped_cxxtype %>, OStrm_>,
                         typename writer_t::formatter_t>::type;
-  return IDL::traits<<%= scoped_cxxtype %>>::write_on (
-      os, w.val_,
-      formatter_t ());
+  return IDL::traits<<%= scoped_cxxtype %>>::write_on (os, w.val_, formatter_t ());
 }
 
 #endif

--- a/ridlbe/c++11/templates/cli/hdr/interface_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_idl_traits.erb
@@ -6,13 +6,9 @@
 template <typename OStrm_>
 struct formatter<<%= scoped_cxxtype %>, OStrm_>
 {
-  OStrm_& operator ()(
-      OStrm_& ,
-      <%= scoped_cxx_in_type %>);
+  OStrm_& operator ()(OStrm_& , <%= scoped_cxx_in_type %>);
 };
 
 template <typename OStrm_, typename Fmt>
-OStrm_& operator <<(
-    OStrm_&,
-    IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt>);
+OStrm_& operator <<(OStrm_&, IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt>);
 #endif // !_INTF_FMT_<%= _intf_fmt_traits_decl_incl_guard_ %>_TRAITS_DECL_

--- a/ridlbe/c++11/templates/cli/hdr/interface_idl_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_idl_traits_def.erb
@@ -2,26 +2,18 @@
 // generated from <%= ridl_template_path %>
 template <typename OStrm_>
 inline OStrm_&
-formatter<<%= scoped_cxxtype %>, OStrm_>::operator ()(
-      OStrm_& os_,
-      <%= scoped_cxx_in_type %> val_)
+formatter<<%= scoped_cxxtype %>, OStrm_>::operator ()(OStrm_& os_, <%= scoped_cxx_in_type %> val_)
 {
 % if is_abstract?
-  os_ << IDL::traits<TAOX11_CORBA::AbstractBase>::_dump (
-           val_,
-           "<%= formatted_cxxname %>");
+  os_ << IDL::traits<TAOX11_CORBA::AbstractBase>::_dump (val_, "<%= formatted_cxxname %>");
 % else
-  os_ << IDL::traits<TAOX11_CORBA::Object>::_dump (
-           std::move (val_),
-           "<%= formatted_cxxname %>");
+  os_ << IDL::traits<TAOX11_CORBA::Object>::_dump (std::move (val_), "<%= formatted_cxxname %>");
 % end
   return os_;
 }
 
 template <typename OStrm_, typename Fmt>
-inline OStrm_& operator <<(
-    OStrm_& os,
-    IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt> w)
+inline OStrm_& operator <<(OStrm_& os, IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
   using writer_t = IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt>;
   using formatter_t = typename std::conditional<
@@ -30,7 +22,5 @@ inline OStrm_& operator <<(
                           std::false_type>::value,
                         formatter<<%= scoped_cxxtype %>, OStrm_>,
                         typename writer_t::formatter_t>::type;
-  return IDL::traits<<%= scoped_cxxtype %>>::write_on (
-      os, w.val_,
-      formatter_t ());
+  return IDL::traits<<%= scoped_cxxtype %>>::write_on (os, w.val_, formatter_t ());
 }

--- a/ridlbe/c++11/templates/cli/hdr/struct_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/struct_idl_traits.erb
@@ -8,9 +8,7 @@ struct traits <<%= scoped_cxxtype %>>
   : IDL::common_traits<<%= scoped_cxxtype %>>
 {
   template <typename OStrm_, typename Formatter = formatter<value_type, OStrm_>>
-  static inline OStrm_& write_on(
-      OStrm_& os_, in_type val_,
-      Formatter fmt_ = Formatter ())
+  static inline OStrm_& write_on(OStrm_& os_, in_type val_, Formatter fmt_ = Formatter ())
   {
     return fmt_ (os_, val_);
   }
@@ -23,7 +21,5 @@ template <typename OStrm_>
 struct formatter<<%= scoped_cxxtype %>, OStrm_>;
 
 template <typename OStrm_, typename Fmt>
-OStrm_& operator <<(
-    OStrm_&,
-    IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt>);
+OStrm_& operator <<(OStrm_&, IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt>);
 #endif // _STRUCT_<%= _struct_traits_incl_guard_ %>_TRAITS_

--- a/ridlbe/c++11/templates/cli/hdr/struct_idl_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/struct_idl_traits_def.erb
@@ -43,9 +43,7 @@ struct formatter<<%= scoped_cxxtype %>, OStrm_>
 };
 
 template <typename OStrm_, typename Fmt>
-inline OStrm_& operator <<(
-    OStrm_& os,
-    IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt> w)
+inline OStrm_& operator <<(OStrm_& os, IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
   using writer_t = IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt>;
   using formatter_t = typename std::conditional<
@@ -54,7 +52,5 @@ inline OStrm_& operator <<(
                           std::false_type>::value,
                         formatter<<%= scoped_cxxtype %>, OStrm_>,
                         typename writer_t::formatter_t>::type;
-  return IDL::traits<<%= scoped_cxxtype %>>::write_on (
-      os, w.val_,
-      formatter_t ());
+  return IDL::traits<<%= scoped_cxxtype %>>::write_on (os, w.val_, formatter_t ());
 }

--- a/ridlbe/c++11/templates/cli/hdr/union_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_idl_traits.erb
@@ -8,9 +8,7 @@ struct traits <<%= scoped_cxxtype %>>
   : IDL::common_traits<<%= scoped_cxxtype %>>
 {
   template <typename OStrm_, typename Formatter = formatter<value_type, OStrm_>>
-  static inline OStrm_& write_on(
-      OStrm_& os_, in_type val_,
-      Formatter fmt_ = Formatter ())
+  static inline OStrm_& write_on(OStrm_& os_, in_type val_, Formatter fmt_ = Formatter ())
   {
     return fmt_ (os_, val_);
   }
@@ -23,7 +21,5 @@ template <typename OStrm_>
 struct formatter<<%= scoped_cxxtype %>, OStrm_>;
 
 template <typename OStrm_, typename Fmt>
-OStrm_& operator <<(
-    OStrm_&,
-    IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt>);
+OStrm_& operator <<(OStrm_&, IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt>);
 #endif // _UNION_<%= _union_traits_incl_guard_ %>_TRAITS_

--- a/ridlbe/c++11/templates/cli/hdr/union_idl_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_idl_traits_def.erb
@@ -3,9 +3,7 @@
 template <typename OStrm_>
 struct formatter<<%= scoped_cxxtype %>, OStrm_>
 {
-  inline OStrm_& operator ()(
-      OStrm_& os_,
-      <%= scoped_cxx_in_type %> val_)
+  inline OStrm_& operator ()(OStrm_& os_, <%= scoped_cxx_in_type %> val_)
   {
     os_ << "<%= formatted_cxxname %> {";
 % if switchtype_boolean?
@@ -74,7 +72,5 @@ inline OStrm_& operator <<(
                           std::false_type>::value,
                         formatter<<%= scoped_cxxtype %>, OStrm_>,
                         typename writer_t::formatter_t>::type;
-  return IDL::traits<<%= scoped_cxxtype %>>::write_on (
-      os, w.val_,
-      formatter_t ());
+  return IDL::traits<<%= scoped_cxxtype %>>::write_on (os, w.val_, formatter_t ());
 }

--- a/ridlbe/c++11/templates/cli/hdr/valuebox_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuebox_idl_traits.erb
@@ -5,9 +5,7 @@ struct formatter<<%= scoped_cxxtype %>, OStrm_>
 {
   using boxed_traits = typename IDL::traits<<%= scoped_cxxtype %>>::boxed_traits;
 
-  inline OStrm_& operator ()(
-      OStrm_& os_,
-      <%= scoped_cxx_in_type %> val_)
+  inline OStrm_& operator ()(OStrm_& os_, <%= scoped_cxx_in_type %> val_)
   {
     os_ << "<%= formatted_cxxname %> {" << boxed_traits::write (val_->_value()) << '}';
     return os_;
@@ -15,9 +13,7 @@ struct formatter<<%= scoped_cxxtype %>, OStrm_>
 };
 
 template <typename OStrm_, typename Fmt>
-inline OStrm_& operator <<(
-    OStrm_& os,
-    IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt> w)
+inline OStrm_& operator <<(OStrm_& os, IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt> w)
 {
   using writer_t = IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt>;
   using formatter_t = typename std::conditional<
@@ -26,7 +22,5 @@ inline OStrm_& operator <<(
                           std::false_type>::value,
                         formatter<<%= scoped_cxxtype %>, OStrm_>,
                         typename writer_t::formatter_t>::type;
-  return IDL::traits<<%= scoped_cxxtype %>>::write_on (
-      os, w.val_,
-      formatter_t ());
+  return IDL::traits<<%= scoped_cxxtype %>>::write_on (os, w.val_, formatter_t ());
 }

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_idl_traits.erb
@@ -7,7 +7,5 @@ template <typename OStrm_>
 struct formatter<<%= scoped_cxxtype %>, OStrm_>;
 
 template <typename OStrm_, typename Fmt>
-OStrm_& operator <<(
-    OStrm_&,
-    IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt>);
+OStrm_& operator <<(OStrm_&, IDL::traits<<%= scoped_cxxtype %>>::__Writer<Fmt>);
 #endif // !_VALUETYPE_<%= _vt_idl_traits_decl_incl_guard_ %>_IDL_TRAITS_DECL_

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_idl_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_idl_traits_def.erb
@@ -43,7 +43,5 @@ inline OStrm_& operator <<(
                           std::false_type>::value,
                         formatter<<%= scoped_cxxtype %>, OStrm_>,
                         typename writer_t::formatter_t>::type;
-  return IDL::traits<<%= scoped_cxxtype %>>::write_on (
-      os, w.val_,
-      formatter_t ());
+  return IDL::traits<<%= scoped_cxxtype %>>::write_on (os, w.val_, formatter_t ());
 }


### PR DESCRIPTION
    * ridlbe/c++11/templates/cli/hdr/ami/interface_amic_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/enum_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/fixed_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/interface_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/interface_idl_traits_def.erb:
    * ridlbe/c++11/templates/cli/hdr/struct_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/struct_idl_traits_def.erb:
    * ridlbe/c++11/templates/cli/hdr/union_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/union_idl_traits_def.erb:
    * ridlbe/c++11/templates/cli/hdr/valuebox_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_idl_traits_def.erb: