### PR TITLE
Fixed visit of valuetype, method was incorrectly named

### DIFF
--- a/ridlbe/c++11/writers/amistubproxy.rb
+++ b/ridlbe/c++11/writers/amistubproxy.rb
@@ -188,7 +188,7 @@ module IDL
         check_idl_type(node.idltype)
       end
 
-      def enter_valuetype(node)
+      def visit_valuetype(node)
         return if node.is_local?
         add_include('tao/x11/basic_argument_t.h')
         node.state_members.each { |m| check_idl_type(m.idltype) }

--- a/ridlbe/c++11/writers/stubproxy.rb
+++ b/ridlbe/c++11/writers/stubproxy.rb
@@ -165,7 +165,7 @@ module IDL
         check_idl_type(node.idltype)
       end
 
-      def enter_valuetype(node)
+      def visit_valuetype(node)
         return if node.is_local?
         add_include('tao/x11/basic_argument_t.h')
         node.state_members.each { |m| check_idl_type(m.idltype) }


### PR DESCRIPTION
    * ridlbe/c++11/writers/amistubproxy.rb:
    * ridlbe/c++11/writers/stubproxy.rb: