### PR TITLE
Remove std::move call to get rid of compiler warning `warning: moving…

### DIFF
--- a/ridlbe/c++11/templates/cli/src/interface_post.erb
+++ b/ridlbe/c++11/templates/cli/src/interface_post.erb
@@ -84,7 +84,7 @@ TAOX11_CORBA::Object::_shared_ptr_type
 <%= scoped_cxx_return_type %>
 <%= cxxname %>::_this ()
 {
-  return IDL::traits<<%= cxxname %>>::narrow (std::move(this->Object::_lock ()));
+  return IDL::traits<<%= cxxname %>>::narrow (this->Object::_lock ());
 }
 % end
 


### PR DESCRIPTION
… a temporary object prevents copy elision [-Wpessimizing-move]`

    * ridlbe/c++11/templates/cli/src/interface_post.erb: