### PR TITLE
Fix hidden warnings about _interface_repository_id. Because object ca…

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/interface_pre.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_pre.erb
@@ -43,7 +43,7 @@ public:
 %   end
 %   if has_abstract_base?
 
-  std::string _interface_repository_id () override;
+  std::string _interface_repository_id () const override;
 %     unless abstractbase_operations.empty?
 
   /** @name Inherited abstract interface operations */

--- a/ridlbe/c++11/templates/cli/src/interface_pre.erb
+++ b/ridlbe/c++11/templates/cli/src/interface_pre.erb
@@ -16,8 +16,7 @@ bool
 % end
 % if has_abstract_base?
 
-std::string
-<%= cxxname %>::_interface_repository_id ()
+std::string <%= cxxname %>::_interface_repository_id () const
 {
   return "<%= repository_id %>";
 }

--- a/tao/x11/PolicyC.cpp
+++ b/tao/x11/PolicyC.cpp
@@ -119,7 +119,7 @@ namespace TAOX11_NAMESPACE {
     // generated from c++/cli_src/interface_pre.erb
     static const std::string TAOX11_NAMESPACE_corba_policy_stub_repo_id_ = "IDL:CORBA/Policy:1.0";
 
-    const std::string& Policy::_interface_repository_id () const
+    std::string Policy::_interface_repository_id () const
     {
       return TAOX11_NAMESPACE_corba_policy_stub_repo_id_;
     }

--- a/tao/x11/PolicyC.h
+++ b/tao/x11/PolicyC.h
@@ -218,7 +218,7 @@ namespace TAOX11_NAMESPACE
       using _traits_type = IDL::traits<Policy>;
       using _ref_type = _traits_type::ref_type;
 
-      virtual const std::string& _interface_repository_id () const;
+      std::string _interface_repository_id () const override;
 
       // generated from c++/cli_hdr/attribute.erb
       virtual TAOX11_CORBA::PolicyType policy_type();

--- a/tao/x11/dynamic_any/dyn_common.cpp
+++ b/tao/x11/dynamic_any/dyn_common.cpp
@@ -854,12 +854,12 @@ namespace TAOX11_NAMESPACE
         }
         else if (value != nullptr)
         {
-          std::string value_id = value->_interface_repository_id ();
-          if ( value_id != "IDL:omg.org/CORBA/AbstractBase:1.0")
+          std::string const value_id = value->_interface_repository_id ();
+          if (value_id != "IDL:omg.org/CORBA/AbstractBase:1.0")
           {
-            std::string my_id = this->type_->id ();
+            std::string const my_id = this->type_->id ();
 
-            if ( value_id !=  my_id)
+            if (value_id != my_id)
             {
                // If 'value' is an objref, this will be a virtual
                // call. If not, it will just compare to the repo id

--- a/tao/x11/object.cpp
+++ b/tao/x11/object.cpp
@@ -213,7 +213,7 @@ namespace TAOX11_NAMESPACE
     }
 #endif
 
-    std::string Object::_interface_repository_id ()
+    std::string Object::_interface_repository_id () const
     {
       if (this->proxy_)
       {

--- a/tao/x11/object.h
+++ b/tao/x11/object.h
@@ -76,7 +76,7 @@ namespace TAOX11_NAMESPACE
 #endif
 
       /// Get the (local) repository id.
-      virtual std::string _interface_repository_id ();
+      virtual std::string _interface_repository_id () const;
 
 #if ! defined (CORBA_E_COMPACT) && ! defined (CORBA_E_MICRO)
       // DII operations to create a request.

--- a/tao/x11/valuetype/abstract_base.cpp
+++ b/tao/x11/valuetype/abstract_base.cpp
@@ -113,7 +113,7 @@ namespace TAOX11_NAMESPACE
       return local_type_id == this->AbstractBase::_obv_repository_id ();
     }
 
-    std::string AbstractBase::_interface_repository_id ()
+    std::string AbstractBase::_interface_repository_id () const
     {
       // make sure to always call the base version here
       return this->AbstractBase::_obv_repository_id ();

--- a/tao/x11/valuetype/abstract_base.h
+++ b/tao/x11/valuetype/abstract_base.h
@@ -45,7 +45,7 @@ namespace TAOX11_NAMESPACE
       virtual bool _is_a (const std::string& local_type_id);
 
       /// Get the (local) repository id (overloaded in derived interfaces).
-      virtual std::string _interface_repository_id ();
+      virtual std::string _interface_repository_id () const;
 
       static bool _abs_marshal (TAO_OutputCDR&, _ref_type);
       static bool _abs_unmarshal (TAO_InputCDR&, _ref_type&);

--- a/tao/x11/valuetype/value_factory_base.cpp
+++ b/tao/x11/valuetype/value_factory_base.cpp
@@ -24,7 +24,7 @@ namespace TAOX11_NAMESPACE
 
     static const std::string ValueFactoryBase_repository_id_ = "IDL:omg.org/CORBA/ValueFactoryBase:1.0";
 
-    const std::string& ValueFactoryBase::_interface_repository_id () const
+    std::string ValueFactoryBase::_interface_repository_id () const
     {
       return ValueFactoryBase_repository_id_;
     }

--- a/tao/x11/valuetype/value_factory_base.h
+++ b/tao/x11/valuetype/value_factory_base.h
@@ -62,7 +62,7 @@ namespace TAOX11_NAMESPACE
     {
     protected:
       ValueFactoryBase () = default;
-       virtual ~ValueFactoryBase ()= default;
+      ~ValueFactoryBase () override = default;
 
       friend struct object_traits<ValueFactoryBase>;
 
@@ -76,7 +76,7 @@ namespace TAOX11_NAMESPACE
       using _traits_type = IDL::traits<ValueFactoryBase>;
       using _ref_type = IDL::traits<ValueFactoryBase>::ref_type;
 
-      virtual const std::string& _interface_repository_id () const;
+      std::string _interface_repository_id () const override;
 
       virtual CORBA::valuetype_reference<CORBA::ValueBase> create_for_unmarshal () = 0;
 


### PR DESCRIPTION
…lls into the proxy which returns a char* we can't return a string&

    * ridlbe/c++11/templates/cli/hdr/interface_pre.erb:
    * ridlbe/c++11/templates/cli/src/interface_pre.erb:
    * tao/x11/PolicyC.cpp:
    * tao/x11/PolicyC.h:
    * tao/x11/dynamic_any/dyn_common.cpp:
    * tao/x11/object.cpp:
    * tao/x11/object.h:
    * tao/x11/valuetype/abstract_base.cpp:
    * tao/x11/valuetype/abstract_base.h:
    * tao/x11/valuetype/value_factory_base.cpp:
    * tao/x11/valuetype/value_factory_base.h: