### PR TITLE
Remove std::move call which triggers warning with newer compilers

### DIFF
--- a/tao/x11/pi/orb_init_info.cpp
+++ b/tao/x11/pi/orb_init_info.cpp
@@ -134,7 +134,7 @@ namespace TAOX11_NAMESPACE
     {
       try {
         TAO_CORBA::StringSeq_var safe_args (this->orbii_->arguments ());
-        return std::move (seq_to_x11<CORBA::StringSeq> (safe_args.in ()));
+        return seq_to_x11<CORBA::StringSeq> (safe_args.in ());
       }
       catch_tao_system_ex (_sx)
       return {};

--- a/tests/pi/ior_interceptor/foo_client_request_interceptor.cpp
+++ b/tests/pi/ior_interceptor/foo_client_request_interceptor.cpp
@@ -38,8 +38,7 @@ FOO_ClientRequestInterceptor::send_request (
   // Verify that the tagged component that was supposed to be embedded
   // into the IOR by the FOO_IORInterceptor is actually in the IOR
   // profile.
-  IOP::TaggedComponent component =
-    std::move (ri->get_effective_component (FOO::COMPONENT_ID));
+  IOP::TaggedComponent component = ri->get_effective_component (FOO::COMPONENT_ID);
 
   // The correct tagged component appears to exist.  Display the
   // contents of the component data, which should be a NULL terminated

--- a/tests/pi/ior_interceptor/foo_iorinterceptor.cpp
+++ b/tests/pi/ior_interceptor/foo_iorinterceptor.cpp
@@ -41,8 +41,7 @@ FOO_IORInterceptor::establish_components (
   CORBA::Any data;
   data <<= name;
 
-  CORBA::OctetSeq encoded_data =
-    std::move (this->codec_->encode_value (data));
+  CORBA::OctetSeq encoded_data = this->codec_->encode_value (data);
 
   // Construct a tagged component.
   IOP::TaggedComponent component;


### PR DESCRIPTION
    * tao/x11/pi/orb_init_info.cpp:
    * tests/pi/ior_interceptor/foo_client_request_interceptor.cpp:
    * tests/pi/ior_interceptor/foo_iorinterceptor.cpp: