### PR TITLE
Add some more illegal IDL examples

### DIFF
--- a/bin/taox11_tests.lst
+++ b/bin/taox11_tests.lst
@@ -80,6 +80,7 @@ tests/idl4/bitmask/run_test.pl:
 tests/idl4/bitmask/run_illegal_idl3_test.pl:
 tests/idl4/explicit_ints/run_test.pl:
 tests/idl4/explicit_ints/run_illegal_idl3_test.pl:
+tests/idl4/illegal_idl/run_test.pl:
 tests/idl4/map/run_test.pl:
 tests/idl4/map/run_illegal_idl3_test.pl:
 tests/idl4/struct_inheritance/run_test.pl:

--- a/tests/idl4/illegal_idl/map_bound_negative.idl
+++ b/tests/idl4/illegal_idl/map_bound_negative.idl
@@ -1,0 +1,10 @@
+/**
+ * @file map_bound_negative.idl
+ * @author Johnny Willemsen
+ *
+ * ridlc shall reject use of a negative bound
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+typedef map<string,long,-1> StringLongMapNegative;

--- a/tests/idl4/illegal_idl/map_bound_zero.idl
+++ b/tests/idl4/illegal_idl/map_bound_zero.idl
@@ -1,0 +1,10 @@
+/**
+ * @file map_bound_zero.idl
+ * @author Johnny Willemsen
+ *
+ * ridlc shall reject use of a bound with value zero
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+typedef map<string,long,0> StringLongMapZero;

--- a/tests/idl4/illegal_idl/run_test.pl
+++ b/tests/idl4/illegal_idl/run_test.pl
@@ -1,0 +1,69 @@
+#---------------------------------------------------------------------
+# @file   run_test.pl
+# @author Mark Drijver
+#
+# @copyright Copyright (c) Remedy IT Expertise BV
+#---------------------------------------------------------------------
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+     & eval 'exec perl -S $0 $argv:q'
+     if 0;
+
+print "IDL test\n";
+
+use lib "$ENV{ACE_ROOT}/bin";
+use PerlACE::TestTarget;
+use File::Spec;
+
+my $status =0;
+my $server = PerlACE::TestTarget::create_target(2) || die "Create target 2 failed\n";
+
+# The location of the ridl utility
+my $ridl = "$ENV{X11_BASE_ROOT}/bin/ridlc";
+
+unless (-e $ridl) {
+  die "ERROR: Cannot find " . $ridl;
+}
+
+opendir(DIRH, ".") or die "Could not open dir. $!";
+@files = grep(/\.idl$/,readdir(DIRH));
+foreach (sort(@files)){
+  print "Testing ", $_, ": ";
+  my $input_file = $_;
+
+  #Redirect the screen output to the null device.
+  open (OLDOUT, ">&STDOUT");
+#  open (STDOUT, ">" . File::Spec->devnull());
+  open (STDOUT, ">" . output);
+  open (OLDERR, ">&STDERR");
+  open (STDERR, ">&STDOUT");
+
+  # Compile the IDL
+  system ("$ridl", "--idl-version 4 $input_file");
+
+  #Redirect the null device output back to the screen
+  open (STDOUT, ">&OLDOUT");
+  open (STDERR, ">&OLDERR");
+
+  $found = 0;
+  open FILE, "<output";
+  while (my $line = <FILE>)
+  {
+    #print $line;
+    if ($line =~ "IDL::Parse")
+    {
+      $found = 1;
+      close FILE;
+      last;
+    }
+  }
+  #print "\nFound: " . $found;
+  if ($found>0) {
+    print "parsing failed as expected.\n";
+  } else {
+    print STDERR "ERROR: Unable to detect expected ridlc error.\n";
+    $status = 1;
+  }
+
+}
+
+exit $status;

--- a/tests/illegal_idl/array_negative.idl
+++ b/tests/illegal_idl/array_negative.idl
@@ -1,0 +1,10 @@
+/**
+ * @file array_negative.idl
+ * @author Johnny Willemsen
+ *
+ * ridlc shall reject use of a negative bound
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+typedef string StringArray[-1];

--- a/tests/illegal_idl/array_zero.idl
+++ b/tests/illegal_idl/array_zero.idl
@@ -1,0 +1,10 @@
+/**
+ * @file array_zero.idl
+ * @author Johnny Willemsen
+ *
+ * ridlc shall reject use of a array with size zero
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+typedef string StringLongMapZero[0];

--- a/tests/illegal_idl/positive_int.idl
+++ b/tests/illegal_idl/positive_int.idl
@@ -3,7 +3,6 @@
  * @author  Johnny Willemsen
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
- * Chamber of commerce Rotterdam nr.276339, The Netherlands
  */
 
 const unsigned short foo = -1;

--- a/tests/illegal_idl/positive_int.idl
+++ b/tests/illegal_idl/positive_int.idl
@@ -1,0 +1,9 @@
+/**
+ * @file    positive_int.idl
+ * @author  Johnny Willemsen
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ * Chamber of commerce Rotterdam nr.276339, The Netherlands
+ */
+
+const unsigned short foo = -1;

--- a/tests/illegal_idl/positive_sequence_bound.idl
+++ b/tests/illegal_idl/positive_sequence_bound.idl
@@ -3,7 +3,6 @@
  * @author  Johnny Willemsen
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
- * Chamber of commerce Rotterdam nr.276339, The Netherlands
  */
 
 typedef sequence<long, -1> long_sequence;

--- a/tests/illegal_idl/positive_string_bound.idl
+++ b/tests/illegal_idl/positive_string_bound.idl
@@ -3,7 +3,6 @@
  * @author  Johnny Willemsen
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
- * Chamber of commerce Rotterdam nr.276339, The Netherlands
  */
 
 typedef string<-1> bound_string;

--- a/tests/illegal_idl/positive_ushort.idl
+++ b/tests/illegal_idl/positive_ushort.idl
@@ -3,7 +3,6 @@
  * @author  Johnny Willemsen
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
- * Chamber of commerce Rotterdam nr.276339, The Netherlands
  */
 
 const unsigned short foo = -1;

--- a/tests/illegal_idl/positive_wstring_bound.idl
+++ b/tests/illegal_idl/positive_wstring_bound.idl
@@ -1,0 +1,10 @@
+/**
+ * @file positive_wstring_bound.idl
+ * @author Johnny Willemsen
+ *
+ * ridlc shall reject use of a negative bound
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+typedef wstring<-1> WStringNegative;

--- a/tests/illegal_idl/union_duplicate_caselabel.idl
+++ b/tests/illegal_idl/union_duplicate_caselabel.idl
@@ -3,7 +3,6 @@
  * @author  Johnny Willemsen
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
- * Chamber of commerce Rotterdam nr.276339, The Netherlands
  */
 
 enum EnumType {VALUE1, VALUE2};

--- a/tests/illegal_idl/union_duplicate_default.idl
+++ b/tests/illegal_idl/union_duplicate_default.idl
@@ -3,7 +3,6 @@
  * @author  Johnny Willemsen
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
- * Chamber of commerce Rotterdam nr.276339, The Netherlands
  */
 
 enum EnumType {VALUE1, VALUE2};

--- a/tests/illegal_idl/union_superfluous_caselabel.idl
+++ b/tests/illegal_idl/union_superfluous_caselabel.idl
@@ -5,7 +5,6 @@
  * Illegal IDL example as reported on TAO_IDL_FE by Clayton Calabrese
 
  * @copyright Copyright (c) Remedy IT Expertise BV
- * Chamber of commerce Rotterdam nr.276339, The Netherlands
  */
 
 enum EnumType {VALUE1, VALUE2};

--- a/tests/tie/client.cpp
+++ b/tests/tie/client.cpp
@@ -5,7 +5,6 @@
  * @brief   CORBA C++11 client application
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
- * Chamber of commerce Rotterdam nr.276339, The Netherlands
  */
 
 #include "testC.h"

--- a/tests/tie/hello.cpp
+++ b/tests/tie/hello.cpp
@@ -3,7 +3,6 @@
  * @author  Johnny Willemsen
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
- * Chamber of commerce Rotterdam nr.276339, The Netherlands
  */
 #include "testlib/taox11_testlog.h"
 #include "hello.h"

--- a/tests/tie/hello.h
+++ b/tests/tie/hello.h
@@ -3,7 +3,6 @@
  * @author  Johnny Willemsen
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
- * Chamber of commerce Rotterdam nr.276339, The Netherlands
  */
 
 #ifndef HELLO_H

--- a/tests/tie/run_test.pl
+++ b/tests/tie/run_test.pl
@@ -3,7 +3,6 @@
 # @author Johnny Willemsen
 #
 # @copyright Copyright (c) Remedy IT Expertise BV
-# Chamber of commerce Rotterdam nr.276339, The Netherlands
 #---------------------------------------------------------------------
 eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
      & eval 'exec perl -S $0 $argv:q'

--- a/tests/tie/server.cpp
+++ b/tests/tie/server.cpp
@@ -5,7 +5,6 @@
  * @brief   CORBA C++11 server application
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
- * Chamber of commerce Rotterdam nr.276339, The Netherlands
  */
 
 #include "hello.h"

--- a/tests/tie/test.idl
+++ b/tests/tie/test.idl
@@ -3,7 +3,6 @@
  * @author  Mark Drijver
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
- * Chamber of commerce Rotterdam nr.276339, The Netherlands
  */
 
 /// Put the interfaces in a module, to avoid global namespace pollution


### PR DESCRIPTION
Using a bound/array size of 0 was allowed, see https://github.com/RemedyIT/ridl/pull/126 for the fix disallowing that