### PR TITLE
Add initial support for specifying a bit_bound for a bit_mask

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/bitmask.erb
+++ b/ridlbe/c++11/templates/cli/hdr/bitmask.erb
@@ -1,10 +1,10 @@
 
 // generated from <%= ridl_template_path %>
 /// @copydoc <%= doc_scoped_name %>
-enum <%= cxxname %>Bit : uint32_t
+enum <%= cxxname %>Bit : <%= bitbound.cxx_member_type %>
 {
   <%= bitvalues.collect {|e| "/// @copydoc #{doc_scoped_name}::#{e.name}\n  #{e.cxxname} = #{e.value}" }.join(",\n  ") %>
 };// <%= cxxname %>Bit
-using <%= cxxname %> = uint32_t;
+using <%= cxxname %> = <%= bitbound.cxx_member_type %>;
 
 % visit_template('typecode') if generate_typecode_support?

--- a/ridlbe/c++11/visitors/bitmask.rb
+++ b/ridlbe/c++11/visitors/bitmask.rb
@@ -17,6 +17,10 @@ module IDL
         }
       end
 
+      def bitbound
+        node.bitbound
+      end
+
       # template mapping
 
       map_template :bitmask, :bitmask

--- a/tests/idl4/bitmask/client.cpp
+++ b/tests/idl4/bitmask/client.cpp
@@ -8,6 +8,8 @@
  */
 
 #include "testC.h"
+#include "testlib/taox11_testlog.h"
+#include <type_traits>
 
 int main (int /*argc*/, char* /*argv*/[])
 {
@@ -17,5 +19,15 @@ int main (int /*argc*/, char* /*argv*/[])
   MyBitMaskBit my_bitmaskbit;
   X11_UNUSED_ARG(my_bitmask);
   X11_UNUSED_ARG(my_bitmaskbit);
+
+  if (!std::is_same<MyBitMaskBound8, uint8_t>::value)
+  {
+    TAOX11_TEST_ERROR << "Type of MyBitMaskBound8 is not uint8_t" << std::endl;
+  }
+  if (!std::is_same<MyBitMaskBound16, uint16_t>::value)
+  {
+    TAOX11_TEST_ERROR << "Type of MyBitMaskBound16 is not uint16_t" << std::endl;
+  }
+
   return 0;
 }

--- a/tests/idl4/bitmask/test.idl
+++ b/tests/idl4/bitmask/test.idl
@@ -11,4 +11,18 @@ bitmask MyBitMask {
   flag2
 };
 
+@bit_bound(8)
+bitmask MyBitMaskBound8 {
+  flag8_1,
+  flag8_2,
+  flag8_3
+};
+
+@bit_bound(16)
+bitmask MyBitMaskBound16 {
+  flag16_1,
+  flag16_2,
+  flag16_3
+};
+
 // https://softwareengineering.stackexchange.com/questions/194412/using-scoped-enums-for-bit-flags-in-c

--- a/tests/idl4/illegal_idl/bitmask_bitbound_65.idl
+++ b/tests/idl4/illegal_idl/bitmask_bitbound_65.idl
@@ -1,5 +1,5 @@
 /**
- * @file bitmask_missingboundvalue.idl
+ * @file bitmask_bitbound_65.idl
  * @author Johnny Willemsen
  *
  * ridlc shall reject use of a bitmask with a bit_bound annotation with value 65

--- a/tests/idl4/illegal_idl/bitmask_bitbound_65.idl
+++ b/tests/idl4/illegal_idl/bitmask_bitbound_65.idl
@@ -1,0 +1,15 @@
+/**
+ * @file bitmask_missingboundvalue.idl
+ * @author Johnny Willemsen
+ *
+ * ridlc shall reject use of a bitmask with a bit_bound annotation with value 65
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+@bit_bound(65)
+bitmask MyBitMask {
+  flag0,
+  flag1,
+  flag2
+};

--- a/tests/idl4/illegal_idl/bitmask_bitbound_missingvalue.idl
+++ b/tests/idl4/illegal_idl/bitmask_bitbound_missingvalue.idl
@@ -1,0 +1,15 @@
+/**
+ * @file bitmask_bitbound_missingvalue.idl
+ * @author Johnny Willemsen
+ *
+ * ridlc shall reject use of a bitmask with a bit_bound annotation with no value
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+@bit_bound()
+bitmask MyBitMask {
+  flag0,
+  flag1,
+  flag2
+};

--- a/tests/idl4/illegal_idl/bitmask_bitbound_negative.idl
+++ b/tests/idl4/illegal_idl/bitmask_bitbound_negative.idl
@@ -1,5 +1,5 @@
 /**
- * @file bitmask_missingboundvalue.idl
+ * @file bitmask_bitbound_negative.idl
  * @author Johnny Willemsen
  *
  * ridlc shall reject use of a bitmask with a negative bit_bound value

--- a/tests/idl4/illegal_idl/bitmask_bitbound_negative.idl
+++ b/tests/idl4/illegal_idl/bitmask_bitbound_negative.idl
@@ -1,0 +1,15 @@
+/**
+ * @file bitmask_missingboundvalue.idl
+ * @author Johnny Willemsen
+ *
+ * ridlc shall reject use of a bitmask with a negative bit_bound value
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+@bit_bound(-1)
+bitmask MyBitMask {
+  flag0,
+  flag1,
+  flag2
+};

--- a/tests/idl4/illegal_idl/bitmask_bitbound_zero.idl
+++ b/tests/idl4/illegal_idl/bitmask_bitbound_zero.idl
@@ -1,5 +1,5 @@
 /**
- * @file bitmask_missingboundvalue.idl
+ * @file bitmask_bitbound_zero.idl
  * @author Johnny Willemsen
  *
  * ridlc shall reject use of a bitmask with a bit_bound annotation with value zero

--- a/tests/idl4/illegal_idl/bitmask_bitbound_zero.idl
+++ b/tests/idl4/illegal_idl/bitmask_bitbound_zero.idl
@@ -1,0 +1,15 @@
+/**
+ * @file bitmask_missingboundvalue.idl
+ * @author Johnny Willemsen
+ *
+ * ridlc shall reject use of a bitmask with a bit_bound annotation with value zero
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+@bit_bound(0)
+bitmask MyBitMask {
+  flag0,
+  flag1,
+  flag2
+};

--- a/tests/idl4/illegal_idl/bitmask_nobitfields.idl
+++ b/tests/idl4/illegal_idl/bitmask_nobitfields.idl
@@ -1,0 +1,11 @@
+/**
+ * @file bitmask_nobitfields.idl
+ * @author Johnny Willemsen
+ *
+ * ridlc shall reject use of a bitmask with no bitfields
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+bitmask MyBitMask {
+};


### PR DESCRIPTION
    * tests/idl4/illegal_idl/bitmask_bitbound_missingvalue.idl:
    * tests/idl4/illegal_idl/bitmask_bitbound_zero.idl:
    * tests/idl4/illegal_idl/bitmask_nobitfields.idl:
      Added.

    * ridlbe/c++11/templates/cli/hdr/bitmask.erb:
    * ridlbe/c++11/visitors/bitmask.rb:
    * tests/idl4/bitmask/client.cpp:
    * tests/idl4/bitmask/test.idl: