### PR TITLE
Make use of C++11 ability to use "namespace A::B"

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_object_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_object_traits.erb
@@ -3,51 +3,48 @@
 % _intf_traits_decl_incl_guard_ = amic_scoped_cxxname.to_include_guard
 #if !defined (_INTF_<%= _intf_traits_decl_incl_guard_ %>_TRAITS_DECL_)
 #define _INTF_<%= _intf_traits_decl_incl_guard_ %>_TRAITS_DECL_
-namespace TAOX11_NAMESPACE
+namespace TAOX11_NAMESPACE::CORBA
 {
-  namespace CORBA
-  {
-    template<>
-    <%= amic_export_macro %>object_traits<<%= amic_scoped_cxxtype %>>::shared_ptr_type
-    object_traits<<%= amic_scoped_cxxtype %>>::lock_shared (<%= amic_scoped_cxxtype %>* p);
+  template<>
+  <%= amic_export_macro %>object_traits<<%= amic_scoped_cxxtype %>>::shared_ptr_type
+  object_traits<<%= amic_scoped_cxxtype %>>::lock_shared (<%= amic_scoped_cxxtype %>* p);
 %   if is_remote?
 
-    template<>
-    <%= amic_export_macro %>object_traits<<%= amic_scoped_cxxtype %>>::ref_type
-    object_traits<<%= amic_scoped_cxxtype %>>::narrow (object_traits<TAOX11_NAMESPACE::CORBA::Object>::ref_type);
+  template<>
+  <%= amic_export_macro %>object_traits<<%= amic_scoped_cxxtype %>>::ref_type
+  object_traits<<%= amic_scoped_cxxtype %>>::narrow (object_traits<TAOX11_NAMESPACE::CORBA::Object>::ref_type);
 %   else
 %     if declare_local_object_narrow_specialization?
 
-    template<>
-    <%= amic_export_macro %>object_traits<<%= amic_scoped_cxxtype %>>::ref_type
-    object_traits<<%= amic_scoped_cxxtype %>>::narrow (object_traits<TAOX11_NAMESPACE::CORBA::Object>::ref_type);
+  template<>
+  <%= amic_export_macro %>object_traits<<%= amic_scoped_cxxtype %>>::ref_type
+  object_traits<<%= amic_scoped_cxxtype %>>::narrow (object_traits<TAOX11_NAMESPACE::CORBA::Object>::ref_type);
 %     end
 %   end
 
-    template<>
-    struct amic_traits <<%= scoped_cxxtype %>> :
-      public IDL::common_byval_traits <CORBA::object_reference <<%= amic_scoped_cxxtype %>>>,
-      public CORBA::object_traits <<%= amic_scoped_cxxtype %>>
+  template<>
+  struct amic_traits <<%= scoped_cxxtype %>> :
+    public IDL::common_byval_traits <CORBA::object_reference <<%= amic_scoped_cxxtype %>>>,
+    public CORBA::object_traits <<%= amic_scoped_cxxtype %>>
+  {
+    using replyhandler_base_type = <%= handler_scoped_skel_cxxname %>;
+    using replyhandler_servant_traits = TAOX11_CORBA::servant_traits<<%= handler_scoped_skel_cxxname %>>;
+    using replyhandler_servant_ref_type = TAOX11_CORBA::servant_reference<<%=handler_scoped_skel_cxxname%>>;
+    using replyhandler_weak_servant_ref_type = TAOX11_CORBA::weak_servant_reference<<%=handler_scoped_skel_cxxname%>>;
+    using replyhandler_traits = IDL::traits<<%= handler_scoped_cxxname %>>;
+    using replyhandler_ref_type = replyhandler_traits::ref_type;
+    using replyhandler_weak_ref_type = replyhandler_traits::weak_ref_type ;
+
+    template <typename OStrm_, typename Formatter = IDL::formatter<<%= amic_scoped_cxxtype %>, OStrm_>>
+    static inline OStrm_& write_on(
+      OStrm_& os_, in_type val_,
+      Formatter fmt_ = Formatter ())
     {
-      using replyhandler_base_type = <%= handler_scoped_skel_cxxname %>;
-      using replyhandler_servant_traits = TAOX11_CORBA::servant_traits<<%= handler_scoped_skel_cxxname %>>;
-      using replyhandler_servant_ref_type = TAOX11_CORBA::servant_reference<<%=handler_scoped_skel_cxxname%>>;
-      using replyhandler_weak_servant_ref_type = TAOX11_CORBA::weak_servant_reference<<%=handler_scoped_skel_cxxname%>>;
-      using replyhandler_traits = IDL::traits<<%= handler_scoped_cxxname %>>;
-      using replyhandler_ref_type = replyhandler_traits::ref_type;
-      using replyhandler_weak_ref_type = replyhandler_traits::weak_ref_type ;
+      return fmt_ (os_, val_);
+    }
 
-      template <typename OStrm_, typename Formatter = IDL::formatter<<%= amic_scoped_cxxtype %>, OStrm_>>
-      static inline OStrm_& write_on(
-          OStrm_& os_, in_type val_,
-          Formatter fmt_ = Formatter ())
-      {
-        return fmt_ (os_, val_);
-      }
-
-      template <typename Formatter = std::false_type>
-      static inline __Writer<Formatter> write (in_type val) { return {val}; }
-    };
-  }  // namespace CORBA
-} // namespace TAOX11_NAMESPACE
+    template <typename Formatter = std::false_type>
+    static inline __Writer<Formatter> write (in_type val) { return {val}; }
+  };
+} // namespace TAOX11_NAMESPACE::CORBA
 #endif // !_INTF_<%= _intf_traits_decl_incl_guard_ %>_TRAITS_DECL_

--- a/ridlbe/c++11/templates/cli/hdr/valuebox_traits_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuebox_traits_def.erb
@@ -1,14 +1,10 @@
 
 // generated from <%= ridl_template_path %>
-namespace TAOX11_NAMESPACE
+namespace TAOX11_NAMESPACE::CORBA
 {
-  namespace CORBA
+  inline valuetype_traits<<%= scoped_cxxtype %>>::ref_type
+  valuetype_traits<<%= scoped_cxxtype %>>::narrow (valuetype_reference<ValueBase> vbref)
   {
-    inline valuetype_traits<<%= scoped_cxxtype %>>::ref_type
-    valuetype_traits<<%= scoped_cxxtype %>>::narrow (
-          valuetype_reference<ValueBase> vbref)
-    {
-      return ref_type::_narrow (vbref);
-    }
-  } // namespace CORBA
-} // namespace TAOX11_NAMESPACE
+    return ref_type::_narrow (vbref);
+  }
+} // namespace TAOX11_NAMESPACE::CORBA

--- a/ridlbe/c++11/writers/amistubheader.rb
+++ b/ridlbe/c++11/writers/amistubheader.rb
@@ -340,19 +340,14 @@ module IDL
       def pre_visit(_parser)
         println
         printiln('// generated from AmiStubHeaderTraitsWriter#pre_visit')
-        printiln('namespace TAOX11_NAMESPACE')
-        printiln('{')
-        inc_nest
-        printiln('namespace IDL')
+        printiln('namespace TAOX11_NAMESPACE::IDL')
         printiln('{')
         inc_nest
       end
 
       def post_visit(_parser)
         dec_nest
-        printiln('} // namespace IDL')
-        dec_nest
-        printiln('} // namespace TAOX11_NAMESPACE')
+        printiln('} // namespace TAOX11_NAMESPACE::IDL')
       end
 
       def enter_interface(node)
@@ -374,21 +369,15 @@ module IDL
         super
         println
         printiln('// generated from AmiStubHeaderAnyOpWriter#pre_visit')
-        println('namespace TAOX11_NAMESPACE')
+        println('namespace TAOX11_NAMESPACE::CORBA')
         println('{')
-        inc_nest
-        println('  namespace CORBA')
-        println('  {')
         inc_nest
       end
 
       def post_visit(parser)
         dec_nest
         println
-        println('  } // namespace CORBA')
-        dec_nest
-        println
-        println('} // namespace TAOX11_NAMESPACE')
+        println('  } // namespace TAOX11_NAMESPACE::CORBA')
         super
       end
 
@@ -616,17 +605,13 @@ module IDL
       def pre_visit(_parser)
         println
         printiln('// generated from AmiStubHeaderSrvTraitsWriter#pre_visit')
-        printiln('namespace TAOX11_NAMESPACE {')
-        inc_nest
-        printiln('namespace CORBA {')
+        printiln('namespace TAOX11_NAMESPACE::CORBA {')
         inc_nest
       end
 
       def post_visit(_parser)
         dec_nest
-        printiln('} // namespace CORBA')
-        dec_nest
-        printiln('} // namespace TAOX11_NAMESPACE')
+        printiln('} // namespace TAOX11_NAMESPACE::CORBA')
       end
 
       def enter_interface(node)

--- a/ridlbe/c++11/writers/amistubsource.rb
+++ b/ridlbe/c++11/writers/amistubsource.rb
@@ -531,21 +531,14 @@ module IDL
       def pre_visit(_parser)
         println
         printiln('// generated from StubSourceObjTraitsWriter#pre_visit')
-        printiln('namespace TAOX11_NAMESPACE')
-        printiln('{')
-        inc_nest
-        println
-        printiln('namespace CORBA')
+        printiln('namespace TAOX11_NAMESPACE::CORBA')
         printiln('{')
         inc_nest
       end
 
       def post_visit(_parser)
         dec_nest
-        printiln('} // namespace CORBA')
-        println
-        dec_nest
-        printiln('} // namespace TAOX11_NAMESPACE')
+        printiln('} // namespace TAOX11_NAMESPACE::CORBA')
       end
 
       def enter_interface(node)
@@ -609,21 +602,15 @@ module IDL
         super
         println
         printiln('// generated from AmiStubSourceAnyOpWriter#pre_visit')
-        println('namespace TAOX11_NAMESPACE')
+        println('namespace TAOX11_NAMESPACE::CORBA')
         println('{')
-        inc_nest
-        println('  namespace CORBA')
-        println('  {')
         inc_nest
       end
 
       def post_visit(parser)
         dec_nest
         println
-        println('  } // namespace CORBA')
-        dec_nest
-        println
-        println('} // namespace TAOX11_NAMESPACE')
+        println('  } // namespace TAOX11_NAMESPACE::CORBA')
         super
       end
 

--- a/ridlbe/c++11/writers/servantheader.rb
+++ b/ridlbe/c++11/writers/servantheader.rb
@@ -152,17 +152,13 @@ module IDL
       def pre_visit(_parser)
         println
         printiln('// generated from ServantHeaderSrvTraitsWriter#pre_visit')
-        printiln('namespace TAOX11_NAMESPACE {')
-        inc_nest
-        printiln('namespace CORBA {')
+        printiln('namespace TAOX11_NAMESPACE::CORBA {')
         inc_nest
       end
 
       def post_visit(_parser)
         dec_nest
-        printiln('} // namespace CORBA')
-        dec_nest
-        printiln('} // namespace TAOX11_NAMESPACE')
+        printiln('} // namespace TAOX11_NAMESPACE::CORBA')
       end
 
       def enter_interface(node)

--- a/ridlbe/c++11/writers/stubheader.rb
+++ b/ridlbe/c++11/writers/stubheader.rb
@@ -475,19 +475,14 @@ module IDL
       def pre_visit(_parser)
         println
         printiln('// generated from StubHeaderIDLTraitsWriter#pre_visit')
-        printiln('namespace TAOX11_NAMESPACE')
+        printiln('namespace TAOX11_NAMESPACE::IDL')
         println('{')
-        inc_nest
-        printiln('namespace IDL')
-        printiln('{')
         inc_nest
       end
 
       def post_visit(_parser)
         dec_nest
-        printiln('} // namespace IDL')
-        dec_nest
-        printiln('} // namespace TAOX11_NAMESPACE')
+        printiln('} // namespace TAOX11_NAMESPACE::IDL')
       end
 
       def declare_interface(node)
@@ -570,19 +565,14 @@ module IDL
       def pre_visit(_parser)
         println
         printiln('// generated from StubHeaderIDLTraitsDefWriter#pre_visit')
-        printiln('namespace TAOX11_NAMESPACE')
+        printiln('namespace TAOX11_NAMESPACE::IDL')
         println('{')
-        inc_nest
-        printiln('namespace IDL')
-        printiln('{')
         inc_nest
       end
 
       def post_visit(_parser)
         dec_nest
-        printiln('} // namespace IDL')
-        dec_nest
-        printiln('} // namespace TAOX11_NAMESPACE')
+        printiln('} // namespace TAOX11_NAMESPACE::IDL')
       end
 
       def enter_interface(node)
@@ -615,21 +605,15 @@ module IDL
         super
         println
         printiln('// generated from StubHeaderAnyOpWriter#pre_visit')
-        println('namespace TAOX11_NAMESPACE')
+        println('namespace TAOX11_NAMESPACE::CORBA')
         println('{')
-        inc_nest
-        println('  namespace CORBA')
-        println('  {')
         inc_nest
       end
 
       def post_visit(parser)
         dec_nest
         println
-        println('  } // namespace CORBA')
-        dec_nest
-        println
-        println('} // namespace TAOX11_NAMESPACE')
+        println('  } // namespace TAOX11_NAMESPACE::CORBA')
         super
       end
 

--- a/ridlbe/c++11/writers/stubsource.rb
+++ b/ridlbe/c++11/writers/stubsource.rb
@@ -451,21 +451,14 @@ module IDL
       def pre_visit(_parser)
         println
         printiln('// generated from StubSourceObjTraitsWriter#pre_visit')
-        printiln('namespace TAOX11_NAMESPACE')
-        printiln('{')
-        inc_nest
-        println
-        printiln('namespace CORBA')
+        printiln('namespace TAOX11_NAMESPACE::CORBA')
         printiln('{')
         inc_nest
       end
 
       def post_visit(_parser)
         dec_nest
-        printiln('} // namespace CORBA')
-        println
-        dec_nest
-        printiln('} // namespace TAOX11_NAMESPACE')
+        printiln('} // namespace TAOX11_NAMESPACE::CORBA')
       end
 
       def enter_interface(node)
@@ -599,21 +592,15 @@ module IDL
         super
         println
         printiln('// generated from StubSourceAnyOpWriter#pre_visit')
-        println('namespace TAOX11_NAMESPACE')
+        println('namespace TAOX11_NAMESPACE::CORBA')
         println('{')
-        inc_nest
-        println('  namespace CORBA')
-        println('  {')
         inc_nest
       end
 
       def post_visit(parser)
         dec_nest
         println
-        println('  } // namespace CORBA')
-        dec_nest
-        println
-        println('} // namespace TAOX11_NAMESPACE')
+        println('  } // namespace TAOX11_NAMESPACE::CORBA')
         super
       end
 


### PR DESCRIPTION
    * ridlbe/c++11/templates/cli/hdr/ami/interface_amic_object_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/valuebox_traits_def.erb:
    * ridlbe/c++11/writers/amistubheader.rb:
    * ridlbe/c++11/writers/amistubsource.rb:
    * ridlbe/c++11/writers/servantheader.rb:
    * ridlbe/c++11/writers/stubheader.rb:
    * ridlbe/c++11/writers/stubsource.rb: