### PR TITLE
More usage of TAOX11_NAMESPACE::PS

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_traits.erb
@@ -1,27 +1,24 @@
 
 // generated from <%= ridl_template_path %>
-namespace IDL
+template <typename OStrm_>
+struct formatter<<%= amic_scoped_cxxtype %>, OStrm_>
 {
-  template <typename OStrm_>
-  struct formatter<<%= amic_scoped_cxxtype %>, OStrm_>
+  inline OStrm_& operator ()(OStrm_& os_, <%= amic_scoped_cxx_in_type %> val_)
   {
-    inline OStrm_& operator ()(OStrm_& os_, <%= amic_scoped_cxx_in_type %> val_)
-    {
-      os_ << IDL::traits<TAOX11_CORBA::Object>::_dump (std::move (val_), "<%= formatted_cxxname %>", true);
-      return os_;
-    }
-  };
-
-  template <typename OStrm_, typename Fmt>
-  inline OStrm_& operator <<(OStrm_& os, TAOX11_CORBA::amic_traits <<%= scoped_cxxtype %>>::__Writer<Fmt> w)
-  {
-    using writer_t = TAOX11_CORBA::amic_traits <<%= scoped_cxxtype %>>::__Writer<Fmt>;
-    using formatter_t = typename std::conditional<
-                          std::is_same<
-                            typename writer_t::formatter_t,
-                            std::false_type>::value,
-                          IDL::formatter<<%= amic_scoped_cxxtype %>, OStrm_>,
-                          typename writer_t::formatter_t>::type;
-    return TAOX11_CORBA::amic_traits <<%= scoped_cxxtype %>>::write_on (os, w.val_, formatter_t ());
+    os_ << IDL::traits<TAOX11_CORBA::Object>::_dump (std::move (val_), "<%= formatted_cxxname %>", true);
+    return os_;
   }
-} // namespace IDL
+};
+
+template <typename OStrm_, typename Fmt>
+inline OStrm_& operator <<(OStrm_& os, TAOX11_CORBA::amic_traits <<%= scoped_cxxtype %>>::__Writer<Fmt> w)
+{
+  using writer_t = TAOX11_CORBA::amic_traits <<%= scoped_cxxtype %>>::__Writer<Fmt>;
+  using formatter_t = typename std::conditional<
+                        std::is_same<
+                          typename writer_t::formatter_t,
+                          std::false_type>::value,
+                        IDL::formatter<<%= amic_scoped_cxxtype %>, OStrm_>,
+                        typename writer_t::formatter_t>::type;
+  return TAOX11_CORBA::amic_traits <<%= scoped_cxxtype %>>::write_on (os, w.val_, formatter_t ());
+}

--- a/ridlbe/c++11/templates/cli/prx/interface_pre.erb
+++ b/ridlbe/c++11/templates/cli/prx/interface_pre.erb
@@ -3,7 +3,7 @@
 class <%= stub_export_macro %><%= proxy_cxxname %>
 % if is_derived?
 %   if !has_concrete_base?
-    : public virtual <%= proxy_root_base %>
+  : public virtual <%= proxy_root_base %>
 %     _first = false
 %   else
 %     _first = true
@@ -13,7 +13,7 @@ class <%= stub_export_macro %><%= proxy_cxxname %>
 %     _first = false
 %   end
 % else
-    : public virtual <%= proxy_root_base %>
+  : public virtual <%= proxy_root_base %>
 % end
 {
 public:

--- a/ridlbe/c++11/templates/srv/src/ami/exceptionholder_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/ami/exceptionholder_traits.erb
@@ -5,7 +5,7 @@
 #define <%= _traits_incl_guard_ %>
 // Arg traits specializations.
 template<>
-class PS::SArg_Traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>
+class SArg_Traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>
   : public Basic_SArg_Traits_T<TAOX11_IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type, Any_Insert_Policy_Stream>
 {
 };

--- a/ridlbe/c++11/templates/srv/src/array_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/array_sarg_traits.erb
@@ -7,7 +7,7 @@
 #define _ALIAS_<%= alias_md5 %>_SARG_TRAITS_
 /// Argument traits specializations for <%= name %>
 template<>
-class PS::SArg_Traits<<%= scoped_cxxtype %>>
+class SArg_Traits<<%= scoped_cxxtype %>>
   : public Basic_SArg_Traits_T<<%= scoped_cxxtype %>, <% if generate_any_support? %>Any_Insert_Policy_Stream<% else %>Any_Insert_Policy_Noop<% end %>>
 {
 };

--- a/ridlbe/c++11/templates/srv/src/bitmask_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/bitmask_sarg_traits.erb
@@ -5,7 +5,7 @@
 # define _<%= _traits_incl_guard_ %>_SARG_TRAITS_
 /// Argument traits specializations for <%= name %>
 template<>
-class PS::SArg_Traits<<%= scoped_cxxtype %>>
+class SArg_Traits<<%= scoped_cxxtype %>>
   : public Basic_SArg_Traits_T<<%= scoped_cxxtype %>, <% if generate_any_support? %>Any_Insert_Policy_Stream<% else %>Any_Insert_Policy_Noop<% end %>>
 {
 };

--- a/ridlbe/c++11/templates/srv/src/bitset_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/bitset_sarg_traits.erb
@@ -5,7 +5,7 @@
 # define _<%= _traits_incl_guard_ %>_SARG_TRAITS_
 /// Argument traits specializations for <%= name %>
 template<>
-class PS::SArg_Traits<<%= scoped_cxxtype %>>
+class SArg_Traits<<%= scoped_cxxtype %>>
   : public Basic_SArg_Traits_T<<%= scoped_cxxtype %>, <% if generate_any_support? %>Any_Insert_Policy_Stream<% else %>Any_Insert_Policy_Noop<% end %>>
 {
 };

--- a/ridlbe/c++11/templates/srv/src/enum_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/enum_sarg_traits.erb
@@ -5,7 +5,7 @@
 # define _<%= _traits_incl_guard_ %>_SARG_TRAITS_
 /// Argument traits specializations for <%= name %>
 template<>
-class PS::SArg_Traits<<%= scoped_cxxtype %>>
+class SArg_Traits<<%= scoped_cxxtype %>>
   : public Basic_SArg_Traits_T<<%= scoped_cxxtype %>,<% if generate_any_support? %>Any_Insert_Policy_Stream<% else %>Any_Insert_Policy_Noop<% end %>>
 {
 };

--- a/ridlbe/c++11/templates/srv/src/interface_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/interface_sarg_traits.erb
@@ -4,7 +4,7 @@
 #if !defined (_<%= _traits_incl_guard_ %>_SARG_TRAITS_)
 #define _<%= _traits_incl_guard_ %>_SARG_TRAITS_
 template<>
-class PS::SArg_Traits<<%= scoped_cxxtype %>>
+class SArg_Traits<<%= scoped_cxxtype %>>
   : public Basic_SArg_Traits_T<<%= scoped_cxx_traits_type %>::ref_type, <% if generate_any_support? %>Any_Insert_Policy_Stream<% else %>Any_Insert_Policy_Noop<% end %>>
 {
 };

--- a/ridlbe/c++11/templates/srv/src/map_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/map_sarg_traits.erb
@@ -7,7 +7,7 @@
 #define _ALIAS_<%= alias_md5 %>_SARG_TRAITS_
 /// Argument traits specializations for <%= name %>
 template<>
-class PS::SArg_Traits<<%= scoped_cxxtype %>>
+class SArg_Traits<<%= scoped_cxxtype %>>
 : public Basic_SArg_Traits_T<<%= scoped_cxxtype %>, <% if generate_any_support? %>Any_Insert_Policy_Stream<% else %>Any_Insert_Policy_Noop<% end %>>
 {
 };

--- a/ridlbe/c++11/templates/srv/src/sequence_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/sequence_sarg_traits.erb
@@ -7,7 +7,7 @@
 #define _ALIAS_<%= alias_md5 %>_SARG_TRAITS_
 /// Argument traits specializations for <%= name %>
 template<>
-class PS::SArg_Traits<<%= scoped_cxxtype %>>
+class SArg_Traits<<%= scoped_cxxtype %>>
   : public Basic_SArg_Traits_T<<%= scoped_cxxtype %>, <% if generate_any_support? %><% if generate_anyinsert_adapter? %>Any_Insert_Policy_AnyInsert_Adapter<% else %>Any_Insert_Policy_Stream<% end %><% else %>Any_Insert_Policy_Noop<% end %>>
 {
 };

--- a/ridlbe/c++11/templates/srv/src/string_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/string_sarg_traits.erb
@@ -7,7 +7,7 @@
 #define _ALIAS_<%= alias_md5 %>_SARG_TRAITS_
 /// Argument traits specializations for <%= name %>
 template<>
-class PS::SArg_Traits<<%= scoped_cxxtype %>>
+class SArg_Traits<<%= scoped_cxxtype %>>
   : public Basic_SArg_Traits_T<<%= scoped_cxxtype %>, <% if generate_any_support? %><% if generate_anyinsert_adapter? %>Any_Insert_Policy_AnyInsert_Adapter<% else %>Any_Insert_Policy_Stream<% end %><% else %>Any_Insert_Policy_Noop<% end %>>
 {
 };

--- a/ridlbe/c++11/templates/srv/src/struct_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/struct_sarg_traits.erb
@@ -5,7 +5,7 @@
 # define _<%= _traits_incl_guard_ %>_SARG_TRAITS_
 /// Argument traits specializations for <%= name %>
 template<>
-class PS::SArg_Traits<<%= scoped_cxxtype %>>
+class SArg_Traits<<%= scoped_cxxtype %>>
   : public Basic_SArg_Traits_T<<%= scoped_cxxtype %>, <% if generate_any_support? %>Any_Insert_Policy_Stream<% else %>Any_Insert_Policy_Noop<% end %>>
 {
 };

--- a/ridlbe/c++11/templates/srv/src/union_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/union_sarg_traits.erb
@@ -5,7 +5,7 @@
 # define _<%= _traits_incl_guard_ %>_SARG_TRAITS_
 /// Argument traits specializations for <%= name %>
 template<>
-class PS::SArg_Traits<<%= scoped_cxxtype %>>
+class SArg_Traits<<%= scoped_cxxtype %>>
   : public Basic_SArg_Traits_T<<%= scoped_cxxtype %>, <% if generate_any_support? %>Any_Insert_Policy_Stream<% else %>Any_Insert_Policy_Noop<% end %>>
 {
 };

--- a/ridlbe/c++11/templates/srv/src/value_sarg_traits.erb
+++ b/ridlbe/c++11/templates/srv/src/value_sarg_traits.erb
@@ -5,7 +5,7 @@
 # define _<%= _traits_incl_guard_ %>_SARG_TRAITS_
 /// Argument traits specializations for <%= name %>
 template<>
-class PS::SArg_Traits<<%= scoped_cxxtype %>>
+class SArg_Traits<<%= scoped_cxxtype %>>
   : public Basic_SArg_Traits_T<<%= scoped_cxx_in_type %>, <% if generate_any_support? %>Any_Insert_Policy_Stream<% else %>Any_Insert_Policy_Noop<% end %>>
 {
 };

--- a/ridlbe/c++11/writers/amistubheader.rb
+++ b/ridlbe/c++11/writers/amistubheader.rb
@@ -511,14 +511,14 @@ module IDL
       def pre_visit(_parser)
         println
         printiln('// generated from AmiStubHeaderAmicTraitsWriter#pre_visit')
-        printiln('namespace TAOX11_NAMESPACE')
+        printiln('namespace TAOX11_NAMESPACE::IDL')
         printiln('{')
         inc_nest
       end
 
       def post_visit(_parser)
         dec_nest
-        printiln('} // namespace TAOX11_NAMESPACE')
+        printiln('} // namespace TAOX11_NAMESPACE::IDL')
       end
 
       def enter_interface(node)

--- a/ridlbe/c++11/writers/amistubsource.rb
+++ b/ridlbe/c++11/writers/amistubsource.rb
@@ -846,13 +846,13 @@ module IDL
         super
         println
         printiln('// generated from AmiStubSourceSArgTraitsWriter#pre_visit')
-        println('namespace TAOX11_NAMESPACE {')
+        println('namespace TAOX11_NAMESPACE::PS {')
         gen_exceptionholder_traits
       end
 
       def post_visit(parser)
         println
-        println('} // namespace TAOX11_NAMESPACE')
+        println('} // namespace TAOX11_NAMESPACE::PS')
         super
       end
 

--- a/ridlbe/c++11/writers/servantsource.rb
+++ b/ridlbe/c++11/writers/servantsource.rb
@@ -282,13 +282,13 @@ module IDL
         super
         println
         printiln('// generated from ServantSourceSArgTraitsWriter#pre_visit')
-        printiln('namespace TAOX11_NAMESPACE')
+        printiln('namespace TAOX11_NAMESPACE::PS')
         printiln('{')
       end
 
       def post_visit(parser)
         println
-        println('} // namespace TAOX11_NAMESPACE')
+        println('} // namespace TAOX11_NAMESPACE:PS')
         super
       end
 

--- a/tao/x11/anytypecode/any_sarg_traits.h
+++ b/tao/x11/anytypecode/any_sarg_traits.h
@@ -20,20 +20,16 @@
 
 #include "tao/x11/object.h"
 
-namespace TAOX11_NAMESPACE
+namespace TAOX11_NAMESPACE::PS
 {
-
-  namespace PS
+  /// Used in generated code if CORBA::Any is an argument or
+  /// return type.
+  template<>
+  class SArg_Traits<TAOX11_NAMESPACE::CORBA::Any>
+    : public Basic_SArg_Traits_T<TAOX11_NAMESPACE::CORBA::Any,
+                                  Any_Insert_Policy_Stream>
   {
-    /// Used in generated code if CORBA::Any is an argument or
-    /// return type.
-    template<>
-    class SArg_Traits<TAOX11_NAMESPACE::CORBA::Any>
-      : public Basic_SArg_Traits_T<TAOX11_NAMESPACE::CORBA::Any,
-                                    Any_Insert_Policy_Stream>
-    {
-    };
-  } // namespace PS
-} // namespace TAOX11_NAMESPACE
+  };
+} // namespace TAOX11_NAMESPACE::PS
 
 #endif /* TAOX11_ANYTYPECODE_ANY_SARG_TRAITS_T_H */

--- a/tao/x11/portable_server/basic_sargument_t.cpp
+++ b/tao/x11/portable_server/basic_sargument_t.cpp
@@ -13,11 +13,8 @@
 #include "tao/x11/portable_server/basic_sargument_t.h"
 #endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
 
-namespace TAOX11_NAMESPACE
+namespace TAOX11_NAMESPACE::PS
 {
-
-namespace PS {
-
 template<typename S,
          template <typename> class Insert_Policy>
 TAO_CORBA::Boolean
@@ -112,8 +109,6 @@ Ret_Basic_SArgument_T<S,Insert_Policy>::interceptor_value (TAO_CORBA::Any *any) 
 
 #endif /* TAO_HAS_INTERCEPTORS */
 
-} // namespace PS
-
-} // namespace TAOX11_NAMESPACE
+} // namespace TAOX11_NAMESPACE::PS
 
 #endif /* TAOX11_BASIC_SARGUMENT_T_CPP */

--- a/tao/x11/portable_server/basic_sarguments.h
+++ b/tao/x11/portable_server/basic_sarguments.h
@@ -18,128 +18,125 @@
 #include "tao/x11/portable_server/basic_sargument_t.h"
 #include "tao/x11/portable_server/long_double_sargument_t.h"
 
-namespace TAOX11_NAMESPACE
+namespace TAOX11_NAMESPACE::PS
 {
-  namespace PS {
-    /**
-     *
-     * @brief Specialization for void return type.
-     *
-     */
-    template<>
-    class TAOX11_PortableServer_Export SArg_Traits<void>
-    {
-    public:
-      using ret_type = void;
-      using ret_val = TAO_TAO::RetArgument;
-    };
+  /**
+    *
+    * @brief Specialization for void return type.
+    *
+    */
+  template<>
+  class TAOX11_PortableServer_Export SArg_Traits<void>
+  {
+  public:
+    using ret_type = void;
+    using ret_val = TAO_TAO::RetArgument;
+  };
 
-    /**
-     *
-     * @brief Specializations for basic skeleton arg types,
-     *  except (w)char/boolean/octet.
-     *
-     */
-    template<>
-    class TAOX11_PortableServer_Export SArg_Traits<int16_t>
-      : public
-          Basic_SArg_Traits_T<
-            int16_t,
-            Any_Insert_Policy_Stream>
-    {
-    };
-
-    template<>
-    class TAOX11_PortableServer_Export SArg_Traits<int32_t>
-      : public
-          Basic_SArg_Traits_T<
-            int32_t,
-            Any_Insert_Policy_Stream>
-    {
-    };
-
-    template<>
-    class TAOX11_PortableServer_Export SArg_Traits<uint16_t>
-      : public
-          Basic_SArg_Traits_T<
-            uint16_t,
-            Any_Insert_Policy_Stream>
-    {
-    };
-
-    template<>
-    class TAOX11_PortableServer_Export SArg_Traits<uint32_t>
-      : public
-          Basic_SArg_Traits_T<
-            uint32_t,
-            Any_Insert_Policy_Stream>
-    {
-    };
-
-    template<>
-    class TAOX11_PortableServer_Export SArg_Traits<float>
-      : public
-          Basic_SArg_Traits_T<
-            float,
-            Any_Insert_Policy_Stream>
-    {
-    };
-
-    template<>
-    class TAOX11_PortableServer_Export SArg_Traits<double>
-      : public
-          Basic_SArg_Traits_T<
-            double,
-            Any_Insert_Policy_Stream>
-    {
-    };
-
-    template<>
-    class TAOX11_PortableServer_Export SArg_Traits<int64_t>
-      : public
-          Basic_SArg_Traits_T<
-            int64_t,
-            Any_Insert_Policy_Stream>
-    {
-    };
-
-    template<>
-    class TAOX11_PortableServer_Export SArg_Traits<uint64_t>
-      : public
-          Basic_SArg_Traits_T<
-            uint64_t,
-            Any_Insert_Policy_Stream>
-    {
-    };
-
-    template<>
-    class TAOX11_PortableServer_Export SArg_Traits<long double>
-      : public
-          Basic_SArg_Traits_T<
-            long double,
-            Any_Insert_Policy_Stream>
-    {
-    };
-
-    template<>
-    class TAOX11_PortableServer_Export SArg_Traits<std::string>
-      : public Basic_SArg_Traits_T<
-          std::string,
+  /**
+    *
+    * @brief Specializations for basic skeleton arg types,
+    *  except (w)char/boolean/octet.
+    *
+    */
+  template<>
+  class TAOX11_PortableServer_Export SArg_Traits<int16_t>
+    : public
+        Basic_SArg_Traits_T<
+          int16_t,
           Any_Insert_Policy_Stream>
-    {
-    };
+  {
+  };
+
+  template<>
+  class TAOX11_PortableServer_Export SArg_Traits<int32_t>
+    : public
+        Basic_SArg_Traits_T<
+          int32_t,
+          Any_Insert_Policy_Stream>
+  {
+  };
+
+  template<>
+  class TAOX11_PortableServer_Export SArg_Traits<uint16_t>
+    : public
+        Basic_SArg_Traits_T<
+          uint16_t,
+          Any_Insert_Policy_Stream>
+  {
+  };
+
+  template<>
+  class TAOX11_PortableServer_Export SArg_Traits<uint32_t>
+    : public
+        Basic_SArg_Traits_T<
+          uint32_t,
+          Any_Insert_Policy_Stream>
+  {
+  };
+
+  template<>
+  class TAOX11_PortableServer_Export SArg_Traits<float>
+    : public
+        Basic_SArg_Traits_T<
+          float,
+          Any_Insert_Policy_Stream>
+  {
+  };
+
+  template<>
+  class TAOX11_PortableServer_Export SArg_Traits<double>
+    : public
+        Basic_SArg_Traits_T<
+          double,
+          Any_Insert_Policy_Stream>
+  {
+  };
+
+  template<>
+  class TAOX11_PortableServer_Export SArg_Traits<int64_t>
+    : public
+        Basic_SArg_Traits_T<
+          int64_t,
+          Any_Insert_Policy_Stream>
+  {
+  };
+
+  template<>
+  class TAOX11_PortableServer_Export SArg_Traits<uint64_t>
+    : public
+        Basic_SArg_Traits_T<
+          uint64_t,
+          Any_Insert_Policy_Stream>
+  {
+  };
+
+  template<>
+  class TAOX11_PortableServer_Export SArg_Traits<long double>
+    : public
+        Basic_SArg_Traits_T<
+          long double,
+          Any_Insert_Policy_Stream>
+  {
+  };
+
+  template<>
+  class TAOX11_PortableServer_Export SArg_Traits<std::string>
+    : public Basic_SArg_Traits_T<
+        std::string,
+        Any_Insert_Policy_Stream>
+  {
+  };
 
 #if !defined(ACE_LACKS_STD_WSTRING)
-    template<>
-    class TAOX11_PortableServer_Export SArg_Traits<std::wstring>
-      : public Basic_SArg_Traits_T<
-          std::wstring,
-          Any_Insert_Policy_Stream>
-    {
-    };
+  template<>
+  class TAOX11_PortableServer_Export SArg_Traits<std::wstring>
+    : public Basic_SArg_Traits_T<
+        std::wstring,
+        Any_Insert_Policy_Stream>
+  {
+  };
 #endif
-
-  } // namespace PS
-} // namespace TAOX11_NAMESPACE
+} // namespace TAOX11_NAMESPACE::PS
 
 #endif /* TAOX11_BASIC_SARGUMENTS_H */

--- a/tao/x11/portable_server/get_skel_arg.h
+++ b/tao/x11/portable_server/get_skel_arg.h
@@ -15,106 +15,103 @@
 #include "tao/x11/arg_traits_t.h"
 #include "tao/x11/portable_server/sarg_traits_t.h"
 
-namespace TAOX11_NAMESPACE
+namespace TAOX11_NAMESPACE::PS
 {
-  namespace PS
+  /// Get return value/argument.
+  template<typename T>
+  typename PS::SArg_Traits<T>::ret_arg_type
+  get_ret_arg (TAO_Operation_Details const * details,
+                TAO::Argument * const * skel_args)
   {
-    /// Get return value/argument.
-    template<typename T>
-    typename PS::SArg_Traits<T>::ret_arg_type
-    get_ret_arg (TAO_Operation_Details const * details,
-                 TAO::Argument * const * skel_args)
+    if (details && details->use_stub_args ())
     {
-      if (details && details->use_stub_args ())
-      {
-        return static_cast<typename TAOX11_NAMESPACE::Arg_Traits<T>::ret_val *> (details->args ()[0])->arg ();
+      return static_cast<typename TAOX11_NAMESPACE::Arg_Traits<T>::ret_val *> (details->args ()[0])->arg ();
 
+    }
+    else
+    {
+      if (skel_args)
+      {
+        return static_cast<typename PS::SArg_Traits<T>::ret_val *> (skel_args[0])->arg ();
       }
       else
       {
-        if (skel_args)
-        {
-          return static_cast<typename PS::SArg_Traits<T>::ret_val *> (skel_args[0])->arg ();
-        }
-        else
-        {
-          throw TAO_CORBA::INTERNAL ();
-        }
+        throw TAO_CORBA::INTERNAL ();
       }
     }
+  }
 
-    /// Get "in" argument.
-    template<typename T>
-    typename PS::SArg_Traits<T>::in_arg_type
-    get_in_arg (TAO_Operation_Details const * details,
-                TAO_TAO::Argument * const * skel_args,
+  /// Get "in" argument.
+  template<typename T>
+  typename PS::SArg_Traits<T>::in_arg_type
+  get_in_arg (TAO_Operation_Details const * details,
+              TAO_TAO::Argument * const * skel_args,
+              size_t i)
+  {
+    if (details && details->use_stub_args ())
+    {
+      return static_cast<typename TAOX11_NAMESPACE::Arg_Traits<T>::in_arg_val *> (details->args ()[i])->arg ();
+    }
+    else
+    {
+      if (skel_args)
+      {
+        return static_cast<typename PS::SArg_Traits<T>::in_arg_val *> (skel_args[i])->arg ();
+      }
+      else
+      {
+        throw TAO_CORBA::INTERNAL ();
+      }
+    }
+  }
+
+  /// Get "inout" argument.
+  template<typename T>
+  typename PS::SArg_Traits<T>::inout_arg_type
+  get_inout_arg (TAO_Operation_Details const * details,
+                  TAO::Argument * const * skel_args,
+                  size_t i)
+  {
+    if (details && details->use_stub_args ())
+    {
+      return static_cast<typename TAOX11_NAMESPACE::Arg_Traits<T>::inout_arg_val *> (details->args ()[i])->arg ();
+    }
+    else
+    {
+      if (skel_args)
+      {
+        return static_cast<typename PS::SArg_Traits<T>::inout_arg_val *> (skel_args[i])->arg ();
+      }
+      else
+      {
+        throw TAO_CORBA::INTERNAL ();
+      }
+    }
+  }
+
+  /// Get "out" argument.
+  template<typename T>
+  typename PS::SArg_Traits<T>::out_arg_type
+  get_out_arg (TAO_Operation_Details const * details,
+                TAO::Argument * const * skel_args,
                 size_t i)
+  {
+    if (details && details->use_stub_args ())
     {
-      if (details && details->use_stub_args ())
+      return static_cast<typename TAOX11_NAMESPACE::Arg_Traits<T>::out_arg_val *> (details->args ()[i])->arg ();
+    }
+    else
+    {
+      if (skel_args)
       {
-        return static_cast<typename TAOX11_NAMESPACE::Arg_Traits<T>::in_arg_val *> (details->args ()[i])->arg ();
+        return static_cast<typename PS::SArg_Traits<T>::out_arg_val *> (skel_args[i])->arg ();
       }
       else
       {
-        if (skel_args)
-        {
-          return static_cast<typename PS::SArg_Traits<T>::in_arg_val *> (skel_args[i])->arg ();
-        }
-        else
-        {
-          throw TAO_CORBA::INTERNAL ();
-        }
+        throw TAO_CORBA::INTERNAL ();
       }
     }
-
-    /// Get "inout" argument.
-    template<typename T>
-    typename PS::SArg_Traits<T>::inout_arg_type
-    get_inout_arg (TAO_Operation_Details const * details,
-                   TAO::Argument * const * skel_args,
-                   size_t i)
-    {
-      if (details && details->use_stub_args ())
-      {
-        return static_cast<typename TAOX11_NAMESPACE::Arg_Traits<T>::inout_arg_val *> (details->args ()[i])->arg ();
-      }
-      else
-      {
-        if (skel_args)
-        {
-          return static_cast<typename PS::SArg_Traits<T>::inout_arg_val *> (skel_args[i])->arg ();
-        }
-        else
-        {
-          throw TAO_CORBA::INTERNAL ();
-        }
-      }
-    }
-
-    /// Get "out" argument.
-    template<typename T>
-    typename PS::SArg_Traits<T>::out_arg_type
-    get_out_arg (TAO_Operation_Details const * details,
-                 TAO::Argument * const * skel_args,
-                 size_t i)
-    {
-      if (details && details->use_stub_args ())
-      {
-        return static_cast<typename TAOX11_NAMESPACE::Arg_Traits<T>::out_arg_val *> (details->args ()[i])->arg ();
-      }
-      else
-      {
-        if (skel_args)
-        {
-          return static_cast<typename PS::SArg_Traits<T>::out_arg_val *> (skel_args[i])->arg ();
-        }
-        else
-        {
-          throw TAO_CORBA::INTERNAL ();
-        }
-      }
-    }
-  } // namespace PS
-} // namespace TAOX11_NAMESPACE
+  }
+} // namespace TAOX11_NAMESPACE::PS
 
 #endif /* TAOX11_GET_SKEL_ARG_T_H */

--- a/tao/x11/portable_server/long_double_sargument_t.cpp
+++ b/tao/x11/portable_server/long_double_sargument_t.cpp
@@ -15,11 +15,8 @@
 
 #if (ACE_SIZEOF_LONG_DOUBLE != 16)
 
-namespace TAOX11_NAMESPACE
+namespace TAOX11_NAMESPACE::PS
 {
-
-namespace PS {
-
 template<template <typename> class Insert_Policy>
 TAO_CORBA::Boolean
 In_Basic_SArgument_T<long double, Insert_Policy>::demarshal (TAO_InputCDR &cdr)
@@ -115,9 +112,7 @@ Ret_Basic_SArgument_T<long double,Insert_Policy>::interceptor_value (TAO_CORBA::
 }
 
 #endif /* TAO_HAS_INTERCEPTORS */
-
-} // namespace PS
-} // namespace TAOX11_NAMESPACE
+} // namespace TAOX11_NAMESPACE::PS
 
 #endif /* ACE_SIZEOF_LONG_DOUBLE != 16 */
 

--- a/tao/x11/portable_server/long_double_sargument_t.h
+++ b/tao/x11/portable_server/long_double_sargument_t.h
@@ -16,10 +16,8 @@
 // In other cases though we have to define a new trait specialization.
 #if (ACE_SIZEOF_LONG_DOUBLE != 16)
 
-namespace TAOX11_NAMESPACE
+namespace TAOX11_NAMESPACE::PS
 {
-  namespace PS
-  {
   /**
    * @class In_Basic_SArgument_T
    *
@@ -112,10 +110,7 @@ namespace TAOX11_NAMESPACE
   private:
     long double x_;
   };
-
-  } // namespace PS
-
-} // namespace TAOX11_NAMESPACE
+} // namespace TAOX11_NAMESPACE::PS
 
 #if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #include "tao/x11/portable_server/long_double_sargument_t.cpp"

--- a/tao/x11/portable_server/sarg_traits_t.h
+++ b/tao/x11/portable_server/sarg_traits_t.h
@@ -16,20 +16,18 @@
 
 #include "tao/x11/stddef.h"
 
-namespace TAOX11_NAMESPACE
+namespace TAOX11_NAMESPACE::PS
 {
-  namespace PS {
-    /**
-    *
-    * @brief Base class for all skeleton arg traits specializations.
-    *
-    */
-    template<typename T>
-    class SArg_Traits
-    {
-    };
-  } // namespace PS
-} // namespace TAOX11_NAMESPACE
+  /**
+  *
+  * @brief Base class for all skeleton arg traits specializations.
+  *
+  */
+  template<typename T>
+  class SArg_Traits
+  {
+  };
+} // namespace TAOX11_NAMESPACE::PS
 
 
 #include /**/ "ace/post.h"

--- a/tao/x11/portable_server/special_basic_sargument_t.cpp
+++ b/tao/x11/portable_server/special_basic_sargument_t.cpp
@@ -13,11 +13,8 @@
 #include "tao/x11/portable_server/special_basic_sargument_t.h"
 #endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
 
-namespace TAOX11_NAMESPACE
+namespace TAOX11_NAMESPACE::PS
 {
-
-namespace PS {
-
 template<typename S,
          typename to_S,
          typename from_S,
@@ -134,8 +131,6 @@ interceptor_value (TAO_CORBA::Any *any) const
 
 #endif /* TAO_HAS_INTERCEPTORS */
 
-} // namespace PS
-
-} // namespace TAOX11_NAMESPACE
+} // namespace TAOX11_NAMESPACE::PS
 
 #endif /* TAO_SPECIAL_BASIC_SARGUMENT_T_CPP */

--- a/tao/x11/portable_server/special_basic_sarguments.h
+++ b/tao/x11/portable_server/special_basic_sarguments.h
@@ -19,10 +19,8 @@
 
 #include "ace/CDR_Stream.h"
 
-namespace TAOX11_NAMESPACE
+namespace TAOX11_NAMESPACE::PS
 {
-
-  namespace PS {
   /**
    *
    * @brief Specializations for (w)char, octet and boolean.
@@ -65,8 +63,6 @@ namespace TAOX11_NAMESPACE
 
   {
   };
-
-  } // namespace PS
-} // namespace TAOX11_NAMESPACE
+} // namespace TAOX11_NAMESPACE::PS
 
 #endif /* TAOX11_SPECIAL_BASIC_SARGUMENTS_H */

--- a/tao/x11/portable_server/stub_sarg_traits.h
+++ b/tao/x11/portable_server/stub_sarg_traits.h
@@ -18,20 +18,17 @@
 #include "tao/x11/portable_server/basic_sargument_t.h"
 #include "tao/x11/object.h"
 
-namespace TAOX11_NAMESPACE
+namespace TAOX11_NAMESPACE::PS
 {
-  namespace PS
+  /// Used in generated code if CORBA::Object is an argument or
+  /// return type.
+  template<>
+  class SArg_Traits<TAOX11_NAMESPACE::CORBA::Object>
+    : public Basic_SArg_Traits_T<
+          TAOX11_CORBA::object_reference<TAOX11_NAMESPACE::CORBA::Object>,
+          Any_Insert_Policy_Stream>
   {
-    /// Used in generated code if CORBA::Object is an argument or
-    /// return type.
-    template<>
-    class SArg_Traits<TAOX11_NAMESPACE::CORBA::Object>
-      : public Basic_SArg_Traits_T<
-            TAOX11_CORBA::object_reference<TAOX11_NAMESPACE::CORBA::Object>,
-            Any_Insert_Policy_Stream>
-    {
-    };
-  } // namespace PS
-} // namespace TAOX11_NAMESPACE
+  };
+} // namespace TAOX11_NAMESPACE::PS
 
 #endif /* TAOX11_STUB_SARG_TRAITS_H */


### PR DESCRIPTION
    * ridlbe/c++11/templates/srv/src/ami/exceptionholder_traits.erb:
    * ridlbe/c++11/templates/srv/src/array_sarg_traits.erb:
    * ridlbe/c++11/templates/srv/src/bitmask_sarg_traits.erb:
    * ridlbe/c++11/templates/srv/src/bitset_sarg_traits.erb:
    * ridlbe/c++11/templates/srv/src/enum_sarg_traits.erb:
    * ridlbe/c++11/templates/srv/src/interface_sarg_traits.erb:
    * ridlbe/c++11/templates/srv/src/map_sarg_traits.erb:
    * ridlbe/c++11/templates/srv/src/sequence_sarg_traits.erb:
    * ridlbe/c++11/templates/srv/src/string_sarg_traits.erb:
    * ridlbe/c++11/templates/srv/src/struct_sarg_traits.erb:
    * ridlbe/c++11/templates/srv/src/union_sarg_traits.erb:
    * ridlbe/c++11/templates/srv/src/value_sarg_traits.erb:
    * ridlbe/c++11/writers/servantsource.rb:
    * tao/x11/anytypecode/any_sarg_traits.h:
    * tao/x11/portable_server/basic_sargument_t.cpp:
    * tao/x11/portable_server/basic_sarguments.h:
    * tao/x11/portable_server/get_skel_arg.h:
    * tao/x11/portable_server/long_double_sargument_t.cpp:
    * tao/x11/portable_server/long_double_sargument_t.h:
    * tao/x11/portable_server/sarg_traits_t.h:
    * tao/x11/portable_server/special_basic_sargument_t.cpp:
    * tao/x11/portable_server/special_basic_sarguments.h:
    * tao/x11/portable_server/stub_sarg_traits.h: