### PR TITLE
Use value_initializer instead of zero_initializer as preparation for …

### DIFF
--- a/ridlbe/c++11/config/cxx_type.rb
+++ b/ridlbe/c++11/config/cxx_type.rb
@@ -155,6 +155,11 @@ module IDL
       '{}'
     end
 
+    # Construct for value initialization
+    def value_initializer
+      zero_initializer
+    end
+
     # define cxxtype methods for 'primitive' types
     {
       Char => 'char',

--- a/ridlbe/c++11/templates/cli/hdr/except_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/except_post.erb
@@ -39,7 +39,7 @@ protected:
 
 private:
 % members.each do |_m|
-  <%= _m.cxx_member_type %> <%= _m.cxxname %>_<%= _m.zero_initializer %>;
+  <%= _m.cxx_member_type %> <%= _m.cxxname %>_<%= _m.value_initializer %>;
 % end
 }; // class <%= cxxname %>
 % visit_template('typecode') if generate_typecode_support?

--- a/ridlbe/c++11/templates/cli/hdr/struct_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/struct_post.erb
@@ -44,7 +44,7 @@
 
 private:
 % members.each do |_m|
-  <%= _m.cxx_member_type %> <%= _m.cxxname %>_<%= _m.zero_initializer %>;
+  <%= _m.cxx_member_type %> <%= _m.cxxname %>_<%= _m.value_initializer %>;
 % end
 };// <%= cxxname %>
 

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -73,14 +73,14 @@ private:
 #endif
     ~u_type_ ();
 % members.each do |_m|
-% # The default member or the first member should use the zero_initializer
+% # The default member or the first member should use the value_initializer
 % # Visual Studio 2019 doesn't seem to like using default, this leads to
 % # an internal compiler error, see SW331
 % if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
 #if defined (_MSC_VER) && (_MSC_VER < 1930)
     <%= _m.cxx_member_type %> <%= _m.cxxname %>_;
 #else
-    <%= _m.cxx_member_type %> <%= _m.cxxname %>_<% if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first) %> <%= _m.zero_initializer %><% end %>;
+    <%= _m.cxx_member_type %> <%= _m.cxxname %>_<% if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first) %> <%= _m.value_initializer %><% end %>;
 #endif
 % else
     <%= _m.cxx_member_type %> <%= _m.cxxname %>_;

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb
@@ -87,7 +87,7 @@ namespace obv
 
   private:
 % members.each do |_m|
-    <%= _m.scoped_cxx_member_type %> <%= _m.cxxname %>_<%= _m.zero_initializer %>;
+    <%= _m.scoped_cxx_member_type %> <%= _m.cxxname %>_<%= _m.value_initializer %>;
 % end
   }; // class <%= cxxname %>
 } // namespace obv

--- a/ridlbe/c++11/templates/cli/inl/union_inl.erb
+++ b/ridlbe/c++11/templates/cli/inl/union_inl.erb
@@ -2,9 +2,9 @@
 #if defined (_MSC_VER) && (_MSC_VER < 1930)
 inline <%= scoped_cxxname %>::u_type_::u_type_ ()
 % if has_default?()
-  : <%= default_member.cxxname %>_<%= default_member.zero_initializer %>
+  : <%= default_member.cxxname %>_<%= default_member.value_initializer %>
 % else
-  : <%= members.first.cxxname %>_<%= members.first.zero_initializer %>
+  : <%= members.first.cxxname %>_<%= members.first.value_initializer %>
 % end
 {
 }

--- a/ridlbe/c++11/templates/cli/src/bitmask_cdr.erb
+++ b/ridlbe/c++11/templates/cli/src/bitmask_cdr.erb
@@ -7,7 +7,7 @@ TAO_CORBA::Boolean operator<< (TAO_OutputCDR &strm, const <%= scoped_cxxname %> 
 
 TAO_CORBA::Boolean operator>> (TAO_InputCDR &strm, <%= scoped_cxxname %> &_tao_bitmask)
 {
-  <%= bitbound.cxx_member_type %> _tao_temp <%= bitbound.zero_initializer %>;
+  <%= bitbound.cxx_member_type %> _tao_temp <%= bitbound.value_initializer %>;
   bool const _tao_success = strm >> <%= bitbound.cdr_to_fmt % "_tao_temp" %>;
 
   if (_tao_success)

--- a/ridlbe/c++11/templates/cli/src/bitset_cdr.erb
+++ b/ridlbe/c++11/templates/cli/src/bitset_cdr.erb
@@ -9,7 +9,7 @@ TAO_CORBA::Boolean operator<< (TAO_OutputCDR &/*strm*/, const <%= scoped_cxxname
 TAO_CORBA::Boolean operator>> (TAO_InputCDR &/*strm*/, <%= scoped_cxxname %> & /*_tao_bitset*/)
 {
   return true;
-%#  <%= bitbound.cxx_member_type %> _tao_temp <%= bitbound.zero_initializer %>;
+%#  <%= bitbound.cxx_member_type %> _tao_temp <%= bitbound.value_initializer %>;
 %#  bool const _tao_success = strm >> <%= bitbound.cdr_to_fmt % "_tao_temp" %>;
 %#
 %#  if (_tao_success)

--- a/ridlbe/c++11/templates/cli/src/enum_cdr.erb
+++ b/ridlbe/c++11/templates/cli/src/enum_cdr.erb
@@ -7,7 +7,7 @@ TAO_CORBA::Boolean operator<< (TAO_OutputCDR &strm, const <%= scoped_cxxname %> 
 
 TAO_CORBA::Boolean operator>> (TAO_InputCDR &strm, <%= scoped_cxxname %> &_tao_enumerator)
 {
-  <%= bitbound.cxx_member_type %> _tao_temp <%= bitbound.zero_initializer %>;
+  <%= bitbound.cxx_member_type %> _tao_temp <%= bitbound.value_initializer %>;
   bool const _tao_success = strm >> <%= bitbound.cdr_to_fmt % "_tao_temp" %>;
 
   if (_tao_success)

--- a/ridlbe/c++11/templates/cli/src/union_cdr.erb
+++ b/ridlbe/c++11/templates/cli/src/union_cdr.erb
@@ -62,7 +62,7 @@ TAO_CORBA::Boolean operator<< (TAO_OutputCDR &strm, const <%= scoped_cxxname %> 
 
 TAO_CORBA::Boolean operator>> (TAO_InputCDR &strm, <%= scoped_cxxname %> &_tao_union)
 {
-  <%= scoped_switch_cxxtype %> _tao_discriminant<%= switchtype.zero_initializer %>;
+  <%= scoped_switch_cxxtype %> _tao_discriminant<%= switchtype.value_initializer %>;
   if (!(strm >> <%= switchtype.cdr_to_fmt % "_tao_discriminant" %>))
   {
     return false;
@@ -75,7 +75,7 @@ TAO_CORBA::Boolean operator>> (TAO_InputCDR &strm, <%= scoped_cxxname %> &_tao_u
 %     # in these cases there is only a single member mapping all labels
 %     _m = _defmem || _ndefmem.shift
   // initialize associated default value
-  <%= _m.cxx_member_type %> temp_val<%= _m.zero_initializer %>;
+  <%= _m.cxx_member_type %> temp_val<%= _m.value_initializer %>;
   // extract
   if (strm >> <%= _m.cdr_to_fmt % "temp_val" %>)
   {
@@ -90,7 +90,7 @@ TAO_CORBA::Boolean operator>> (TAO_InputCDR &strm, <%= scoped_cxxname %> &_tao_u
   if (<%= _lbl == 'false' ? '!' : '' %>_tao_discriminant)
   {
     // initialize associated default value
-    <%= _m.cxx_member_type %> temp_val<%= _m.zero_initializer %>;
+    <%= _m.cxx_member_type %> temp_val<%= _m.value_initializer %>;
     // extract
     if (strm >> <%= _m.cdr_to_fmt % "temp_val" %>)
     {
@@ -104,7 +104,7 @@ TAO_CORBA::Boolean operator>> (TAO_InputCDR &strm, <%= scoped_cxxname %> &_tao_u
   {
 %     _m = _defmem || _ndefmem.shift # get other (non-)default member
     // initialize associated default value
-    <%= _m.cxx_member_type %> temp_val<%= _m.zero_initializer %>;
+    <%= _m.cxx_member_type %> temp_val<%= _m.value_initializer %>;
     // extract
     if (strm >> <%= _m.cdr_to_fmt % "temp_val" %>)
     {
@@ -125,7 +125,7 @@ TAO_CORBA::Boolean operator>> (TAO_InputCDR &strm, <%= scoped_cxxname %> &_tao_u
 %     end
     {
       // initialize associated default value
-      <%= _m.cxx_member_type %> temp_val<%= _m.zero_initializer %>;
+      <%= _m.cxx_member_type %> temp_val<%= _m.value_initializer %>;
       // extract
       if (strm >> <%= _m.cdr_to_fmt % "temp_val" %>)
       {
@@ -143,7 +143,7 @@ TAO_CORBA::Boolean operator>> (TAO_InputCDR &strm, <%= scoped_cxxname %> &_tao_u
 %     _m_def = default_member
     {
       // initialize associated default value
-      <%= _m_def.cxx_member_type %> temp_val<%= _m_def.zero_initializer %>;
+      <%= _m_def.cxx_member_type %> temp_val<%= _m_def.value_initializer %>;
       // extract
       if (strm >> <%= _m_def.cdr_to_fmt % "temp_val" %>)
       {

--- a/ridlbe/c++11/visitorbase.rb
+++ b/ridlbe/c++11/visitorbase.rb
@@ -523,6 +523,10 @@ module IDL
         self._idltype.zero_initializer
       end
 
+      def value_initializer
+        self._idltype.value_initializer
+      end
+
       # template mapping
 
       # this seems nonsensical but this prevents prefixing


### PR DESCRIPTION
…future support for default annotation

    * ridlbe/c++11/config/cxx_type.rb:
    * ridlbe/c++11/templates/cli/hdr/except_post.erb:
    * ridlbe/c++11/templates/cli/hdr/struct_post.erb:
    * ridlbe/c++11/templates/cli/hdr/union_post.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb:
    * ridlbe/c++11/templates/cli/inl/union_inl.erb:
    * ridlbe/c++11/templates/cli/src/bitmask_cdr.erb:
    * ridlbe/c++11/templates/cli/src/bitset_cdr.erb:
    * ridlbe/c++11/templates/cli/src/enum_cdr.erb:
    * ridlbe/c++11/templates/cli/src/union_cdr.erb:
    * ridlbe/c++11/visitorbase.rb: