### PR TITLE
Make make_reference a constexpr function

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/ami/attribute.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/attribute.erb
@@ -2,17 +2,13 @@
 // generated from <%= ridl_template_path %>
 /// @copydoc <%= doc_scoped_name %>
 //@{
-void
-get_<%= name %> (<%= scoped_cxx_in_type %> ami_return_val);
+void get_<%= name %> (<%= scoped_cxx_in_type %> ami_return_val);
 
-void
-get_<%= name %>_excep (IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder);
+void get_<%= name %>_excep (IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder);
 % unless is_readonly?
 
-void
-set_<%= name %> ();
+void set_<%= name %> ();
 
-void
-set_<%= name %>_excep (IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder);
+void set_<%= name %>_excep (IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder);
 % end
 //@}

--- a/ridlbe/c++11/templates/cli/hdr/ami/attribute_amic.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/attribute_amic.erb
@@ -1,12 +1,10 @@
 
 // generated from <%= ridl_template_path %>
-void
-<%= sendc_prefix_get %><%= name %> (
-    <%= interface.handler_scoped_cxx_in_type %> ami_handler);
+void <%= sendc_prefix_get %><%= name %> (
+  <%= interface.handler_scoped_cxx_in_type %> ami_handler);
 % unless is_readonly?
 
-void
-<%= sendc_prefix_set %><%= name %> (
-    <%= interface.handler_scoped_cxx_in_type %> ami_handler,
-    <%= cxx_in_type %> _x11_<%= cxxname %>);
+void <%= sendc_prefix_set %><%= name %> (
+  <%= interface.handler_scoped_cxx_in_type %> ami_handler,
+  <%= cxx_in_type %> _x11_<%= cxxname %>);
 % end

--- a/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/interface_amic_post.erb
@@ -7,7 +7,7 @@ protected:
   using _shared_ptr_type = std::shared_ptr<<%= cxxname %>>;
 
   template <typename _Tp1, typename, typename ...Args>
-  friend TAOX11_CORBA::object_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);
+  friend constexpr TAOX11_CORBA::object_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);
 
   explicit <%= amic_cxxname %> (<%= proxy_cxxname %>_ptr p, bool inherited = false);
   <%= amic_cxxname %> () = default;

--- a/ridlbe/c++11/templates/cli/hdr/ami/operation.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/operation.erb
@@ -11,5 +11,4 @@ void
     <%= _arg.direction == :out ? _arg.scoped_cxx_in_type : _arg.scoped_cxx_inout_type%> <%= _arg.cxxname %><%= _args.empty? ? ');' : ',' %>
 %   end
 
-void
-<%= name %>_excep (IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder);
+void <%= name %>_excep (IDL::traits<TAOX11_NAMESPACE::Messaging::ExceptionHolder>::ref_type excep_holder);

--- a/ridlbe/c++11/templates/cli/hdr/ami/operation_amic.erb
+++ b/ridlbe/c++11/templates/cli/hdr/ami/operation_amic.erb
@@ -1,9 +1,8 @@
 // generated from <%= ridl_template_path %>
 %   _args = in_arguments.dup
-void
-<%= sendc_prefix %><%= name %> (
-    <%= interface.handler_scoped_cxx_in_type %> ami_handler<%= _args.empty? ? ');' : ',' %>
+void <%= sendc_prefix %><%= name %> (
+  <%= interface.handler_scoped_cxx_in_type %> ami_handler<%= _args.empty? ? ');' : ',' %>
 %   while !_args.empty?
 %     _arg = _args.shift
-    <%= _arg.stub_arg_type %> <%= _arg.cxxname %><%= _args.empty? ? ');' : ',' %>
+  <%= _arg.stub_arg_type %> <%= _arg.cxxname %><%= _args.empty? ? ');' : ',' %>
 %   end

--- a/ridlbe/c++11/templates/cli/hdr/interface_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_post.erb
@@ -44,7 +44,7 @@ protected:
   using _shared_ptr_type = std::shared_ptr<<%= cxxname %>>;
 
   template <typename _Tp1, typename, typename ...Args>
-  friend TAOX11_CORBA::object_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);
+  friend constexpr TAOX11_CORBA::object_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);
 
   explicit <%= cxxname %> (<%= proxy_cxxname %>_ptr p, bool inherited = false);
   /// Default constructor

--- a/ridlbe/c++11/templates/cli/hdr/valuebox_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuebox_def.erb
@@ -27,7 +27,7 @@ public:
 
 protected:
   template <typename _Tp1, typename, typename ...Args>
-  friend TAOX11_CORBA::valuetype_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);
+  friend constexpr TAOX11_CORBA::valuetype_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);
 
   static const std::string __<%= cxxname.downcase %>_repository_id;
 

--- a/ridlbe/c++11/templates/cli/hdr/valuebox_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuebox_traits.erb
@@ -18,7 +18,7 @@ namespace TAOX11_NAMESPACE
       static ref_type narrow (valuetype_reference<ValueBase>);
 
       template <typename ...Args>
-      inline static ref_type make_reference(Args&& ...args)
+      inline static constexpr ref_type make_reference(Args&& ...args)
       {
         return TAOX11_CORBA::make_reference<<%= scoped_cxxtype %>> (std::forward<Args> (args)...);
       }

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_init.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_init.erb
@@ -9,7 +9,7 @@ public:
   template <typename T> friend struct TAOX11_CORBA::object_traits;
 % if is_concrete?
   template <typename _Tp1, typename, typename ...Args>
-  friend TAOX11_CORBA::object_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);
+  friend constexpr TAOX11_CORBA::object_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);
 
   TAOX11_IDL::traits<TAOX11_CORBA::ValueBase>::ref_type
   create_for_unmarshal () override;

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb
@@ -44,7 +44,7 @@ namespace obv
   public:
 % if is_concrete?
     template <typename _Tp1, typename, typename ...Args>
-    friend TAOX11_CORBA::valuetype_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);
+    friend constexpr TAOX11_CORBA::valuetype_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);
 
     TAOX11_IDL::traits<TAOX11_CORBA::ValueBase>::ref_type _copy_value () const override;
 

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_traits.erb
@@ -59,7 +59,7 @@ namespace TAOX11_NAMESPACE
                 typename = typename
                   std::enable_if<std::is_base_of<<%= scoped_cxxtype %>, TInst>::value>::type,
                 typename ...Args>
-      inline static ref_type make_reference(Args&& ...args)
+      inline static constexpr ref_type make_reference(Args&& ...args)
       {
         return TAOX11_CORBA::make_reference<TInst> (std::forward<Args> (args)...);
       }

--- a/ridlbe/c++11/templates/cli/prx/ami/attribute.erb
+++ b/ridlbe/c++11/templates/cli/prx/ami/attribute.erb
@@ -1,14 +1,14 @@
 
 // generated from <%= ridl_template_path %>
 static void get_<%= name %>_reply_stub (
-      TAO_InputCDR &_tao_reply_cdr,
-      TAO_MESSAGING::ReplyHandler_ptr _tao_reply_handler,
-      TAO_CORBA::ULong reply_status);
+  TAO_InputCDR &_tao_reply_cdr,
+  TAO_MESSAGING::ReplyHandler_ptr _tao_reply_handler,
+  TAO_CORBA::ULong reply_status);
 % unless is_readonly?
 
 static void set_<%= name %>_reply_stub (
-      TAO_InputCDR &_tao_reply_cdr,
-      TAO_MESSAGING::ReplyHandler_ptr _reply_handler,
-      TAO_CORBA::ULong reply_status);
+  TAO_InputCDR &_tao_reply_cdr,
+  TAO_MESSAGING::ReplyHandler_ptr _reply_handler,
+  TAO_CORBA::ULong reply_status);
 
 % end

--- a/ridlbe/c++11/templates/cli/prx/ami/operation.erb
+++ b/ridlbe/c++11/templates/cli/prx/ami/operation.erb
@@ -1,5 +1,5 @@
 // generated from <%= ridl_template_path %>
 static void <%= name %>_reply_stub (
-      TAO_InputCDR &_tao_reply_cdr,
-      TAO_MESSAGING::ReplyHandler_ptr _tao_reply_handler,
-      TAO_CORBA::ULong reply_status);
+  TAO_InputCDR &_tao_reply_cdr,
+  TAO_MESSAGING::ReplyHandler_ptr _tao_reply_handler,
+  TAO_CORBA::ULong reply_status);

--- a/ridlbe/c++11/templates/cli/src/ami/attribute_amic.erb
+++ b/ridlbe/c++11/templates/cli/src/ami/attribute_amic.erb
@@ -1,9 +1,8 @@
 % unless interface.is_local?
 
 // generated from <%= ridl_template_path %>
-void
-<%= interface.amic_scoped_cxxname %>::<%= sendc_prefix_get %><%= name %>(
-    <%= interface.handler_scoped_cxx_in_type %> ami_handler)
+void <%= interface.amic_scoped_cxxname %>::<%= sendc_prefix_get %><%= name %>(
+  <%= interface.handler_scoped_cxx_in_type %> ami_handler)
 {
 %   if interface.is_abstract?
   if (!this->_is_object ())
@@ -58,10 +57,9 @@ void
 }
 
 %   unless is_readonly?
-void
-<%= interface.amic_scoped_cxxname %>::<%= sendc_prefix_set %><%= name %>(
-    <%= interface.handler_scoped_cxx_in_type %> ami_handler,
-    <%= cxx_in_type %> _x11_<%= cxxname %>)
+void <%= interface.amic_scoped_cxxname %>::<%= sendc_prefix_set %><%= name %>(
+  <%= interface.handler_scoped_cxx_in_type %> ami_handler,
+  <%= cxx_in_type %> _x11_<%= cxxname %>)
 {
 %   if interface.is_abstract?
   if (!this->_is_object ())

--- a/ridlbe/c++11/templates/cli/src/ami/operation_amic.erb
+++ b/ridlbe/c++11/templates/cli/src/ami/operation_amic.erb
@@ -2,12 +2,11 @@
 
 // generated from <%= ridl_template_path %>
 %     _args = in_arguments.dup
-void
-<%= interface.amic_scoped_cxxname %>::<%= sendc_prefix %><%= name %> (
-    <%= interface.handler_scoped_cxx_in_type %> ami_handler<%= _args.empty? ? ')' : ',' %>
+void <%= interface.amic_scoped_cxxname %>::<%= sendc_prefix %><%= name %> (
+  <%= interface.handler_scoped_cxx_in_type %> ami_handler<%= _args.empty? ? ')' : ',' %>
 %     while !_args.empty?
 %       _arg = _args.shift
-    <%= _arg.stub_arg_type %> <%= _arg.cxxname %><%= _args.empty? ? ')' : ',' %>
+  <%= _arg.stub_arg_type %> <%= _arg.cxxname %><%= _args.empty? ? ')' : ',' %>
 %     end
 {
 %     if interface.is_abstract?

--- a/ridlbe/c++11/templates/impl/hdr/attribute.erb
+++ b/ridlbe/c++11/templates/impl/hdr/attribute.erb
@@ -4,6 +4,5 @@
 <%= cxxname %> () override;
 % unless is_readonly?
 
-void
-<%= cxxname %> (<%= implementation_in_type %> _v) override;
+void <%= cxxname %> (<%= implementation_in_type %> _v) override;
 % end

--- a/ridlbe/c++11/templates/impl/hdr/interface_pre.erb
+++ b/ridlbe/c++11/templates/impl/hdr/interface_pre.erb
@@ -6,19 +6,12 @@ namespace _impl
     : public CORBA::servant_traits<<%= scoped_cxxtype %>>::base_type
 % nest { write_regen_section("#{scoped_cxxname}"+'[Base List]', default_content: '// your base classes') }
   {
-  protected:
+  public:
 % nest(2) { write_regen_section("#{scoped_cxxname}"+'[Constructors]', default_content: ['/// Constructor(s)', "#{skel_cxxname} ();"]) }
 
     /// Destructor
     ~<%= skel_cxxname %> () override;
 
-    template <typename T> friend class CORBA::servant_reference;
-
-    template <typename _Tp1, typename, typename ...Args>
-    friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
-
-% nest(2) { write_regen_section("#{scoped_cxxname}"+'[User Protected]', default_content: '// your protected definitions') }
-  public:
 %   if has_abstract_base?
 %     unless abstractbase_operations.empty?
 
@@ -39,4 +32,6 @@ namespace _impl
     //@}
 %     end
 %   end
+% nest(2) { write_regen_section("#{scoped_cxxname}"+'[User Protected]', default_content: '// your protected definitions') }
+
 % inc_nest

--- a/ridlbe/c++11/templates/impl/hdr/interface_pre.erb
+++ b/ridlbe/c++11/templates/impl/hdr/interface_pre.erb
@@ -15,7 +15,7 @@ namespace _impl
     template <typename T> friend class CORBA::servant_reference;
 
     template <typename _Tp1, typename, typename ...Args>
-    friend CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
+    friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
 
 % nest(2) { write_regen_section("#{scoped_cxxname}"+'[User Protected]', default_content: '// your protected definitions') }
   public:

--- a/ridlbe/c++11/templates/srv/prx/ami/interface_post.erb
+++ b/ridlbe/c++11/templates/srv/prx/ami/interface_post.erb
@@ -3,34 +3,34 @@
 %all_operations.each do |_op|
 %   unless _op.is_inherited?
   static void <%= _op.name %>_skel (
-      TAO_ServerRequest & server_request,
-      TAO_TAO::Portable_Server::Servant_Upcall * servant_upcall,
-      skel_type& servant);
+    TAO_ServerRequest & server_request,
+    TAO_TAO::Portable_Server::Servant_Upcall * servant_upcall,
+    skel_type& servant);
   static void <%= _op.name %>_excep_skel (
-      TAO_ServerRequest & server_request,
-      TAO_TAO::Portable_Server::Servant_Upcall * servant_upcall,
-      skel_type& servant);
+    TAO_ServerRequest & server_request,
+    TAO_TAO::Portable_Server::Servant_Upcall * servant_upcall,
+    skel_type& servant);
 %   end
 %end
 %all_attributes.each do |_att|
 %   unless _att.is_inherited?
   static void get_<%= _att.name %>_skel (
-      TAO_ServerRequest & server_request,
-      TAO_TAO::Portable_Server::Servant_Upcall * servant_upcall,
-      skel_type& servant);
+    TAO_ServerRequest & server_request,
+    TAO_TAO::Portable_Server::Servant_Upcall * servant_upcall,
+    skel_type& servant);
   static void get_<%= _att.name %>_excep_skel (
-      TAO_ServerRequest & server_request,
-      TAO_TAO::Portable_Server::Servant_Upcall * servant_upcall,
-      skel_type& servant);
+    TAO_ServerRequest & server_request,
+    TAO_TAO::Portable_Server::Servant_Upcall * servant_upcall,
+    skel_type& servant);
 %   unless _att.is_readonly?
   static void set_<%= _att.name %>_skel (
-      TAO_ServerRequest & server_request,
-      TAO_TAO::Portable_Server::Servant_Upcall * servant_upcall,
-      skel_type& servant);
+    TAO_ServerRequest & server_request,
+    TAO_TAO::Portable_Server::Servant_Upcall * servant_upcall,
+    skel_type& servant);
   static void set_<%= _att.name %>_excep_skel (
-      TAO_ServerRequest & server_request,
-      TAO_TAO::Portable_Server::Servant_Upcall * servant_upcall,
-      skel_type& servant);
+    TAO_ServerRequest & server_request,
+    TAO_TAO::Portable_Server::Servant_Upcall * servant_upcall,
+    skel_type& servant);
 %     end
 %   end
 %end

--- a/tao/x11/PolicyC.h
+++ b/tao/x11/PolicyC.h
@@ -234,7 +234,7 @@ namespace TAOX11_NAMESPACE
 
     protected:
       template <typename _Tp1, typename, typename ...Args>
-      friend object_reference<_Tp1> make_reference(Args&& ...args);
+      friend constexpr object_reference<_Tp1> make_reference(Args&& ...args);
 
       Policy ();
       explicit Policy (TAOX11_NAMESPACE::Object_proxy_ptr op);

--- a/tao/x11/object.h
+++ b/tao/x11/object.h
@@ -147,7 +147,7 @@ namespace TAOX11_NAMESPACE
 
       template <typename T> friend struct object_traits;
       template <typename _Tp1, typename, typename ...Args>
-      friend object_reference<_Tp1> make_reference(Args&& ...args);
+      friend constexpr object_reference<_Tp1> make_reference(Args&& ...args);
 
       explicit Object (Object_proxy_ptr op = nullptr);
       Object(const Object&) = delete;

--- a/tao/x11/object_traits_t.h
+++ b/tao/x11/object_traits_t.h
@@ -34,7 +34,7 @@ namespace TAOX11_NAMESPACE
 
     template <typename T, typename = typename
       std::enable_if<std::is_base_of<CORBA::Object, T>::value>::type, typename ...Args>
-    object_reference<T> make_reference(Args&& ...args);
+    constexpr object_reference<T> make_reference(Args&& ...args);
 
     template <typename T>
     class weak_object_reference;
@@ -56,7 +56,7 @@ namespace TAOX11_NAMESPACE
           typename = typename
             std::enable_if<std::is_base_of<T, TInst>::value>::type,
           typename ...Args>
-      static inline object_reference<T> make_reference(Args&& ...args)
+      static inline constexpr object_reference<T> make_reference(Args&& ...args)
       {
         return TAOX11_CORBA::make_reference<TInst>(std::forward<Args> (args)...);
       }
@@ -131,7 +131,7 @@ namespace TAOX11_NAMESPACE
       template <typename _Tp1> friend class abstractbase_reference;
       template <typename _Tp1> friend class weak_abstractbase_reference;
       template <typename _Tp1, typename, typename ...Args>
-      friend object_reference<_Tp1> make_reference(Args&& ...args);
+      friend constexpr object_reference<_Tp1> make_reference(Args&& ...args);
       friend class Object;
 
       template<typename _Tp1, typename = typename
@@ -239,7 +239,7 @@ namespace TAOX11_NAMESPACE
     }
 
     template <typename T, typename, typename ...Args>
-    inline object_reference<T> make_reference(Args&& ...args)
+    inline constexpr object_reference<T> make_reference(Args&& ...args)
     {
       return object_reference<T> (new T (std::forward<Args> (args)...));
     }

--- a/tao/x11/orb.h
+++ b/tao/x11/orb.h
@@ -357,7 +357,7 @@ namespace TAOX11_NAMESPACE
       friend ORB_Registry;
 
       template <typename _Tp1, typename, typename ...Args>
-      friend object_reference<_Tp1> make_reference(Args&& ...args);
+      friend constexpr object_reference<_Tp1> make_reference(Args&& ...args);
 
       explicit ORB (ORB_Proxy_ptr op);
 

--- a/tao/x11/portable_server/poa_policies_impl.h
+++ b/tao/x11/portable_server/poa_policies_impl.h
@@ -28,7 +28,7 @@ namespace TAOX11_NAMESPACE {
     \
     protected: \
       template <typename _Tp1, typename, typename ...Args> \
-      friend CORBA::object_reference<_Tp1> CORBA::make_reference(Args&& ...args); \
+      friend constexpr CORBA::object_reference<_Tp1> CORBA::make_reference(Args&& ...args); \
       \
       explicit name ## _impl (TAO_PORTABLE_SERVER::name ## _ptr _pol); \
       ~name ## _impl () = default; \

--- a/tao/x11/portable_server/portableserver_impl.h
+++ b/tao/x11/portable_server/portableserver_impl.h
@@ -164,7 +164,7 @@ namespace TAOX11_NAMESPACE {
 
     private:
       template <typename _Tp1, typename, typename ...Args>
-      friend CORBA::object_reference<_Tp1> CORBA::make_reference(Args&& ...args);
+      friend constexpr CORBA::object_reference<_Tp1> CORBA::make_reference(Args&& ...args);
 
       explicit POA_impl (POA_proxy_ptr op);
 
@@ -213,7 +213,7 @@ namespace TAOX11_NAMESPACE {
 
     private:
       template <typename _Tp1, typename, typename ...Args>
-      friend CORBA::object_reference<_Tp1> CORBA::make_reference(Args&& ...args);
+      friend constexpr CORBA::object_reference<_Tp1> CORBA::make_reference(Args&& ...args);
 
       explicit POAManager_impl (POAManager_proxy_ptr op);
 
@@ -254,7 +254,7 @@ namespace TAOX11_NAMESPACE {
 
     private:
       template <typename _Tp1, typename, typename ...Args>
-      friend CORBA::object_reference<_Tp1> CORBA::make_reference(Args&& ...args);
+      friend constexpr CORBA::object_reference<_Tp1> CORBA::make_reference(Args&& ...args);
 
       explicit POAManagerFactory_impl (POAManagerFactory_proxy_ptr op);
 
@@ -293,7 +293,7 @@ namespace TAOX11_NAMESPACE {
 
     private:
       template <typename _Tp1, typename, typename ...Args>
-      friend CORBA::object_reference<_Tp1> CORBA::make_reference(Args&& ...args);
+      friend constexpr CORBA::object_reference<_Tp1> CORBA::make_reference(Args&& ...args);
 
       explicit POA_Current_impl (POA_Current_proxy_ptr op);
 

--- a/tao/x11/portable_server/servant_traits_t.h
+++ b/tao/x11/portable_server/servant_traits_t.h
@@ -35,7 +35,7 @@ namespace TAOX11_NAMESPACE
 
     template <typename T, typename = typename
       std::enable_if<std::is_base_of<PortableServer::Servant, T>::value>::type, typename ...Args>
-    servant_reference<T> make_reference(Args&& ...args);
+    constexpr servant_reference<T> make_reference(Args&& ...args);
 
     template <typename T>
     class weak_servant_reference;
@@ -133,7 +133,7 @@ namespace TAOX11_NAMESPACE
       template <typename _Tp1> friend class valuetype_reference;
       template <typename _Tp1> friend class weak_valuetype_reference;
       template <typename _Tp1, typename, typename ...Args>
-      friend servant_reference<_Tp1> make_reference(Args&& ...args);
+      friend constexpr servant_reference<_Tp1> make_reference(Args&& ...args);
       friend class PortableServer::Servant;
 
       template <typename _Tp1>
@@ -232,7 +232,7 @@ namespace TAOX11_NAMESPACE
     };
 
     template <typename T, typename, typename ...Args>
-    inline servant_reference<T> make_reference(Args&& ...args)
+    inline constexpr servant_reference<T> make_reference(Args&& ...args)
     {
       return servant_reference<T> (new T (std::forward<Args> (args)...));
     }

--- a/tao/x11/portable_server/servantbase.h
+++ b/tao/x11/portable_server/servantbase.h
@@ -66,7 +66,7 @@ namespace TAOX11_NAMESPACE {
     protected:
       using _shared_ptr_type =_ref_type::shared_ptr_type;
       template <typename _Tp1, typename, typename ...Args>
-      friend CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
+      friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
 
       virtual ~Servant () = default;
 

--- a/tao/x11/valuetype/valuetype_traits_t.h
+++ b/tao/x11/valuetype/valuetype_traits_t.h
@@ -46,7 +46,7 @@ namespace TAOX11_NAMESPACE
       std::enable_if<std::is_base_of<typename
         std::conditional<std::is_base_of<PortableServer::Servant, T>::value, void, CORBA::ValueBase>::type, T>::value>::type,
               typename ...Args>
-    valuetype_reference<T> make_reference(Args&& ...args);
+    constexpr valuetype_reference<T> make_reference(Args&& ...args);
 
     template <typename T>
     class weak_valuetype_reference;
@@ -65,7 +65,7 @@ namespace TAOX11_NAMESPACE
       }
 
       template <typename TInst = T, typename ...Args>
-      inline static valuetype_reference<T> make_reference(Args&& ...args)
+      inline static constexpr valuetype_reference<T> make_reference(Args&& ...args)
       {
         return TAOX11_CORBA::make_reference<TInst> (std::forward<Args> (args)...);
       }
@@ -160,7 +160,7 @@ namespace TAOX11_NAMESPACE
       template <typename _Tp1> friend class abstractbase_reference;
       template <typename _Tp1> friend class weak_abstractbase_reference;
       template <typename _Tp1, typename, typename ...Args>
-      friend valuetype_reference<_Tp1> make_reference(Args&& ...args);
+      friend constexpr valuetype_reference<_Tp1> make_reference(Args&& ...args);
       friend class ValueBase;
 
       template<typename _Tp1, typename = typename
@@ -253,10 +253,8 @@ namespace TAOX11_NAMESPACE
       weak_ptr_type vtp_;
     };
 
-    template <typename T,
-              typename,
-              typename ...Args>
-    inline valuetype_reference<T> make_reference(Args&& ...args)
+    template <typename T, typename, typename ...Args>
+    inline constexpr valuetype_reference<T> make_reference(Args&& ...args)
     {
       return valuetype_reference<T> (new T (std::forward<Args> (args)...));
     }

--- a/tests/ami_test/ami/server.cpp
+++ b/tests/ami_test/ami/server.cpp
@@ -69,7 +69,6 @@ main(int argc, ACE_TCHAR *argv[])
       CORBA::servant_traits<A::AMI_Test>::ref_type hello_impl =
         CORBA::make_reference<AMI_Test_i> (_orb);
 
-
       TAOX11_TEST_INFO << "created A::AMI_Test servant" << std::endl;
 
       PortableServer::ObjectId id = root_poa->activate_object (hello_impl);

--- a/tests/ami_test/ami_collocation/collocation_tester.cpp
+++ b/tests/ami_test/ami_collocation/collocation_tester.cpp
@@ -109,10 +109,8 @@ Collocation_Test::init (int argc, char *argv[])
     return 1;
   }
 
-
   CORBA::servant_traits<A::AMI_Test>::ref_type hello_impl =
      CORBA::make_reference<AMI_Test_i> ();
-
 
   TAOX11_TEST_INFO << "created A::AMI_Test servant" << std::endl;
 
@@ -128,7 +126,6 @@ Collocation_Test::init (int argc, char *argv[])
                       << std::endl;
     return 1;
   }
-
 
   CORBA::amic_traits<A::AMI_Test>::replyhandler_servant_ref_type test_handler_impl =
           CORBA::make_reference<Handler> ();

--- a/tests/ami_test/annotations/server.cpp
+++ b/tests/ami_test/annotations/server.cpp
@@ -68,7 +68,6 @@ main(int argc, ACE_TCHAR *argv[])
       CORBA::servant_traits<A::AMI_Test>::ref_type hello_impl =
         CORBA::make_reference<AMI_Test_i> (_orb);
 
-
       TAOX11_TEST_INFO << "created Hello servant" << std::endl;
 
       PortableServer::ObjectId id = root_poa->activate_object (hello_impl);

--- a/tests/ami_test/attr_raises/server.cpp
+++ b/tests/ami_test/attr_raises/server.cpp
@@ -68,7 +68,6 @@ main(int argc, ACE_TCHAR *argv[])
       CORBA::servant_traits<A::AMI_Test>::ref_type hello_impl =
         CORBA::make_reference<AMI_Test_i> (_orb);
 
-
       TAOX11_TEST_INFO << "created Hello servant" << std::endl;
 
       PortableServer::ObjectId id = root_poa->activate_object (hello_impl);

--- a/tests/custom_format/custom_format_impl.h
+++ b/tests/custom_format/custom_format_impl.h
@@ -32,7 +32,7 @@ namespace Test
   // your base classes
   //@@{__RIDL_REGEN_MARKER__} - END : Test::Foo_impl[Base List]
   {
-  protected:
+  public:
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Foo_impl[Constructors]
     /// Constructor(s)'
     Foo_impl (IDL::traits<CORBA::ORB>::ref_type orb);
@@ -41,15 +41,9 @@ namespace Test
     /// Destructor
     ~Foo_impl () override;
 
-    template <typename T> friend class CORBA::servant_reference;
-
-    template <typename _Tp1, typename, typename ...Args>
-    friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
-
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Foo_impl[User Protected]
     // your protected definitions
     //@@{__RIDL_REGEN_MARKER__} - END : Test::Foo_impl[User Protected]
-  public:
 
     // generated from c++11/templates/impl/hdr/operation.erb
     /// @copydoc Test::Foo::write_on_servant

--- a/tests/custom_format/custom_format_impl.h
+++ b/tests/custom_format/custom_format_impl.h
@@ -39,12 +39,12 @@ namespace Test
     //@@{__RIDL_REGEN_MARKER__} - END : Test::Foo_impl[Constructors]
 
     /// Destructor
-    virtual ~Foo_impl ();
+    ~Foo_impl () override;
 
     template <typename T> friend class CORBA::servant_reference;
 
     template <typename _Tp1, typename, typename ...Args>
-    friend CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
+    friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
 
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Foo_impl[User Protected]
     // your protected definitions

--- a/tests/hello_regen/test_impl.cpp
+++ b/tests/hello_regen/test_impl.cpp
@@ -19,7 +19,6 @@ namespace Test
   // generated from ImplSourceWriter#enter_interface
 
   // generated from c++11/templates/impl/src/interface_pre
-
   namespace _impl {
 
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Foo[Constructors]
@@ -38,7 +37,6 @@ namespace Test
     }
 
     // generated from c++11/templates/impl/src/interface_post
-
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Foo[User Public]
     // your public implementations
     //@@{__RIDL_REGEN_MARKER__} - END : Test::Foo[User Public]
@@ -57,7 +55,6 @@ namespace Test
   // generated from ImplSourceWriter#enter_interface
 
   // generated from c++11/templates/impl/src/interface_pre
-
   namespace _impl {
 
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Hello[Constructors]
@@ -137,7 +134,6 @@ namespace Test
   }
 
     // generated from c++11/templates/impl/src/interface_post
-
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Hello[User Public]
     // your public implementations
     //@@{__RIDL_REGEN_MARKER__} - END : Test::Hello[User Public]

--- a/tests/hello_regen/test_impl.h
+++ b/tests/hello_regen/test_impl.h
@@ -43,7 +43,7 @@ namespace Test
       template <typename T> friend class CORBA::servant_reference;
 
       template <typename _Tp1, typename, typename ...Args>
-      friend CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
+      friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
 
       //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Foo[User Protected]
       // your protected definitions
@@ -89,7 +89,7 @@ namespace Test
       template <typename T> friend class CORBA::servant_reference;
 
       template <typename _Tp1, typename, typename ...Args>
-      friend CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
+      friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
 
       //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Hello[User Protected]
       // your protected definitions
@@ -100,8 +100,7 @@ namespace Test
       int32_t
       int_prop () override;
 
-      void
-      int_prop (int32_t _v) override;
+      void int_prop (int32_t _v) override;
 
       // generated from c++11/templates/impl/hdr/operation
       /// @copydoc test.idl::Test::Hello::get_string

--- a/tests/hello_regen/test_impl.h
+++ b/tests/hello_regen/test_impl.h
@@ -31,7 +31,7 @@ namespace Test
     // your base classes
     //@@{__RIDL_REGEN_MARKER__} - END : Test::Foo[Base List]
     {
-    protected:
+    public:
       //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Foo[Constructors]
       /// Constructor(s)
       Foo ();
@@ -40,15 +40,10 @@ namespace Test
       /// Destructor
       ~Foo () override;
 
-      template <typename T> friend class CORBA::servant_reference;
-
-      template <typename _Tp1, typename, typename ...Args>
-      friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
-
       //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Foo[User Protected]
       // your protected definitions
       //@@{__RIDL_REGEN_MARKER__} - END : Test::Foo[User Protected]
-    public:
+
 
       // generated from c++11/templates/impl/hdr/interface_post
       //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Foo[User Public]
@@ -77,7 +72,7 @@ namespace Test
     // your base classes
     //@@{__RIDL_REGEN_MARKER__} - END : Test::Hello[Base List]
     {
-    protected:
+    public:
       //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Hello[Constructors]
       /// Constructor(s)
       Hello (IDL::traits<CORBA::ORB>::ref_type orb);
@@ -86,15 +81,10 @@ namespace Test
       /// Destructor
       ~Hello () override;
 
-      template <typename T> friend class CORBA::servant_reference;
-
-      template <typename _Tp1, typename, typename ...Args>
-      friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
-
       //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Hello[User Protected]
       // your protected definitions
       //@@{__RIDL_REGEN_MARKER__} - END : Test::Hello[User Protected]
-    public:
+
 
       // generated from c++11/templates/impl/hdr/attribute
       int32_t

--- a/tests/obv/simple/client_i.h
+++ b/tests/obv/simple/client_i.h
@@ -27,7 +27,7 @@ public:
   void shutdown () override;
 
   template <typename _Tp1, typename, typename ...Args>
-  friend CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
+  friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
 
 protected:
   using base_type = CORBA::servant_traits<Test::Client>::base_type;
@@ -43,7 +43,6 @@ private:
   Client_i (Client_i&&) = delete;
   Client_i& operator= (const Client_i&) = delete;
   Client_i& operator= (Client_i&&) = delete;
-
 };
 
 #endif

--- a/tests/obv/simple/client_i.h
+++ b/tests/obv/simple/client_i.h
@@ -26,10 +26,6 @@ public:
 
   void shutdown () override;
 
-  template <typename _Tp1, typename, typename ...Args>
-  friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
-
-protected:
   using base_type = CORBA::servant_traits<Test::Client>::base_type;
 
   Client_i (CORBA::ORB::_ref_type orb)

--- a/tests/write_traits/write_traits_impl.h
+++ b/tests/write_traits/write_traits_impl.h
@@ -32,7 +32,7 @@ namespace Test
   // your base classes
   //@@{__RIDL_REGEN_MARKER__} - END : Test::Foo_impl[Base List]
   {
-  protected:
+  public:
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Foo_impl[Constructors]
     /// Constructor(s)'
     Foo_impl (IDL::traits<CORBA::ORB>::ref_type orb);
@@ -41,15 +41,9 @@ namespace Test
     /// Destructor
     ~Foo_impl () override;
 
-    template <typename T> friend class CORBA::servant_reference;
-
-    template <typename _Tp1, typename, typename ...Args>
-    friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
-
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Foo_impl[User Protected]
     // your protected definitions
     //@@{__RIDL_REGEN_MARKER__} - END : Test::Foo_impl[User Protected]
-  public:
 
     // generated from c++11/templates/impl/hdr/operation.erb
     /// @copydoc Test::Foo::write_on_servant

--- a/tests/write_traits/write_traits_impl.h
+++ b/tests/write_traits/write_traits_impl.h
@@ -39,12 +39,12 @@ namespace Test
     //@@{__RIDL_REGEN_MARKER__} - END : Test::Foo_impl[Constructors]
 
     /// Destructor
-    virtual ~Foo_impl ();
+    ~Foo_impl () override;
 
     template <typename T> friend class CORBA::servant_reference;
 
     template <typename _Tp1, typename, typename ...Args>
-    friend CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
+    friend constexpr CORBA::servant_reference<_Tp1> CORBA::make_reference(Args&& ...args);
 
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test::Foo_impl[User Protected]
     // your protected definitions


### PR DESCRIPTION
    * ridlbe/c++11/templates/cli/hdr/ami/interface_amic_post.erb:
    * ridlbe/c++11/templates/cli/hdr/interface_post.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_init.erb:
    * tao/x11/PolicyC.h:
    * tao/x11/object.h:
    * tao/x11/object_traits_t.h:
    * tao/x11/orb.h:
    * tao/x11/portable_server/poa_policies_impl.h:
    * tao/x11/portable_server/portableserver_impl.h: