### PR TITLE
Use std::integral_constant of uint8_t, not uint32_t, this matches the…

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/bitmask_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/bitmask_idl_traits.erb
@@ -8,7 +8,7 @@ struct traits <<%= scoped_cxxtype %>>
   using underlying_type = <%= bitbound.cxx_type %>;
 
   /// bit_bound
-  using bit_bound = std::integral_constant<uint32_t, <%= bitbound_bits %>>;
+  using bit_bound = std::integral_constant<uint8_t, <%= bitbound_bits %>>;
 
   template <typename OStrm_, typename Formatter = formatter<value_type, OStrm_>>
   static inline OStrm_& write_on(OStrm_& os_, in_type val_, Formatter fmt_ = Formatter ())

--- a/ridlbe/c++11/templates/cli/hdr/enum_idl_traits.erb
+++ b/ridlbe/c++11/templates/cli/hdr/enum_idl_traits.erb
@@ -8,7 +8,7 @@ struct traits <<%= scoped_cxxtype %>>
   using underlying_type = <%= bitbound.cxx_type %>;
 
   /// bit_bound
-  using bit_bound = std::integral_constant<uint32_t, <%= bitbound_bits %>>;
+  using bit_bound = std::integral_constant<uint8_t, <%= bitbound_bits %>>;
 
   template <typename OStrm_, typename Formatter = formatter<value_type, OStrm_>>
   static inline OStrm_& write_on(OStrm_& os_, in_type val_, Formatter fmt_ = Formatter ())


### PR DESCRIPTION
… v1.7 IDL to C++11 spec

    * ridlbe/c++11/templates/cli/hdr/bitmask_idl_traits.erb:
    * ridlbe/c++11/templates/cli/hdr/enum_idl_traits.erb: