### PR TITLE
Moved object and wstring/wchar ostream insertion to their own files a…

### DIFF
--- a/bin/taox11_tests.lst
+++ b/bin/taox11_tests.lst
@@ -180,6 +180,7 @@ tests/typecode_adapter/orb_create/run_test.pl: !CORBA_E_COMPACT !CORBA_E_MICRO
 tests/typecode_adapter/resolve_ref/run_test.pl: !CORBA_E_COMPACT !CORBA_E_MICRO
 tests/union/run_test.pl:
 tests/union/run_cross_tao_server.pl:
+tests/wchar/run_test.pl:
 tests/write_traits/run_test.pl:
 tests/wstring/run_cross_tao_client.pl:
 tests/wstring/run_cross_tao_server.pl:

--- a/ridlbe/c++11/writers/amistubheader.rb
+++ b/ridlbe/c++11/writers/amistubheader.rb
@@ -44,7 +44,7 @@ module IDL
           end
         end
         @default_post_includes << 'tao/x11/anytypecode/typecode_constants.h' if params[:gen_typecodes]
-        @default_post_includes << 'tao/x11/corba_ostream.h' if params[:gen_ostream_operators]
+        @default_post_includes << 'tao/x11/object_ostream.h' if params[:gen_ostream_operators]
         @default_post_includes << 'tao/x11/messaging/messaging.h'
         @default_post_includes << 'tao/x11/amic_traits_t.h'
         @default_post_includes << 'tao/x11/portable_server/servantbase.h'

--- a/ridlbe/c++11/writers/stubheader.rb
+++ b/ridlbe/c++11/writers/stubheader.rb
@@ -435,7 +435,7 @@ module IDL
         idl_type = node.idltype.resolved_type
         case idl_type
         when IDL::Type::WChar
-          add_post_include('tao/x11/wstringwchar_ostream.h') if params[:gen_ostream_operators]
+          check_idl_type(idl_type)
         when IDL::Type::Fixed
           add_include('tao/x11/fixed_t.h')
         when IDL::Type::Sequence
@@ -456,7 +456,7 @@ module IDL
         when IDL::Type::WString
           add_include('tao/x11/bounded_string_t.h') if idl_type.size.to_i.positive?
           add_include('tao/x11/bounded_type_traits_t.h') if idl_type.size.to_i.positive?
-          add_post_include('tao/x11/wstringwchar_ostream.h') if params[:gen_ostream_operators]
+          check_idl_type(idl_type)
         end
       end
 
@@ -475,6 +475,9 @@ module IDL
           add_include('tao/x11/portable_server/servant_forward.h')
         when IDL::Type::AbstractBase
           add_post_include('tao/x11/valuetype/abstract_base.h')
+        when IDL::Type::WString
+             IDL::Type::WChar
+          add_post_include('tao/x11/wstringwchar_ostream.h') if params[:gen_ostream_operators]
         end
       end
 

--- a/ridlbe/c++11/writers/stubheader.rb
+++ b/ridlbe/c++11/writers/stubheader.rb
@@ -450,8 +450,8 @@ module IDL
           check_idl_type(idl_type.valuetype)
         when IDL::Type::Array
           check_idl_type(idl_type.basetype)
-        when IDL::Type::String
-        when IDL::Type::WString
+        when IDL::Type::String,
+             IDL::Type::WString
           add_include('tao/x11/bounded_string_t.h') if idl_type.size.to_i.positive?
           add_include('tao/x11/bounded_type_traits_t.h') if idl_type.size.to_i.positive?
           check_idl_type(idl_type)

--- a/ridlbe/c++11/writers/stubheader.rb
+++ b/ridlbe/c++11/writers/stubheader.rb
@@ -451,6 +451,7 @@ module IDL
         when IDL::Type::Array
           check_idl_type(idl_type.basetype)
         when IDL::Type::String
+        when IDL::Type::WString
           add_include('tao/x11/bounded_string_t.h') if idl_type.size.to_i.positive?
           add_include('tao/x11/bounded_type_traits_t.h') if idl_type.size.to_i.positive?
           check_idl_type(idl_type)

--- a/ridlbe/c++11/writers/stubheader.rb
+++ b/ridlbe/c++11/writers/stubheader.rb
@@ -43,7 +43,6 @@ module IDL
           end
         end
         @default_post_includes << 'tao/x11/anytypecode/typecode_constants.h' if params[:gen_typecodes]
-        @default_post_includes << 'tao/x11/corba_ostream.h' if params[:gen_ostream_operators]
 
         @include_guard = "__RIDL_#{File.basename(params[:output] || '').to_random_include_guard}_INCLUDED__"
 
@@ -377,6 +376,7 @@ module IDL
         else
           add_post_include('tao/x11/anytypecode/typecode.h') # in case not added yet
           add_post_include('tao/x11/valuetype/abstract_base.h') # after typecode include
+          add_post_include('tao/x11/corba_ostream.h') if params[:gen_ostream_operators]
         end
       end
 
@@ -433,6 +433,8 @@ module IDL
 
         idl_type = node.idltype.resolved_type
         case idl_type
+        when IDL::Type::WChar
+          add_post_include('tao/x11/wstringwchar_ostream.h') if params[:gen_ostream_operators]
         when IDL::Type::Fixed
           add_include('tao/x11/fixed_t.h')
         when IDL::Type::Sequence
@@ -447,9 +449,13 @@ module IDL
           check_idl_type(idl_type.valuetype)
         when IDL::Type::Array
           check_idl_type(idl_type.basetype)
-        when IDL::Type::String, IDL::Type::WString
+        when IDL::Type::String
           add_include('tao/x11/bounded_string_t.h') if idl_type.size.to_i.positive?
           add_include('tao/x11/bounded_type_traits_t.h') if idl_type.size.to_i.positive?
+        when IDL::Type::WString
+          add_include('tao/x11/bounded_string_t.h') if idl_type.size.to_i.positive?
+          add_include('tao/x11/bounded_type_traits_t.h') if idl_type.size.to_i.positive?
+          add_post_include('tao/x11/wstringwchar_ostream.h') if params[:gen_ostream_operators]
         end
       end
 

--- a/ridlbe/c++11/writers/stubheader.rb
+++ b/ridlbe/c++11/writers/stubheader.rb
@@ -370,7 +370,7 @@ module IDL
       def enter_interface(node)
         return if node.is_pseudo?
 
-        add_post_include('tao/x11/object_ostream.h') if params[:gen_ostream_operators]
+        add_post_include('tao/x11/object_ostream.h')
 
         unless node.is_abstract?
           add_include('tao/x11/object.h')

--- a/ridlbe/c++11/writers/stubheader.rb
+++ b/ridlbe/c++11/writers/stubheader.rb
@@ -370,13 +370,14 @@ module IDL
       def enter_interface(node)
         return if node.is_pseudo?
 
+        add_post_include('tao/x11/object_ostream.h') if params[:gen_ostream_operators]
+
         unless node.is_abstract?
           add_include('tao/x11/object.h')
           add_include('tao/x11/system_exception.h')
         else
           add_post_include('tao/x11/anytypecode/typecode.h') # in case not added yet
           add_post_include('tao/x11/valuetype/abstract_base.h') # after typecode include
-          add_post_include('tao/x11/corba_ostream.h') if params[:gen_ostream_operators]
         end
       end
 

--- a/ridlbe/c++11/writers/stubheader.rb
+++ b/ridlbe/c++11/writers/stubheader.rb
@@ -453,9 +453,6 @@ module IDL
         when IDL::Type::String
           add_include('tao/x11/bounded_string_t.h') if idl_type.size.to_i.positive?
           add_include('tao/x11/bounded_type_traits_t.h') if idl_type.size.to_i.positive?
-        when IDL::Type::WString
-          add_include('tao/x11/bounded_string_t.h') if idl_type.size.to_i.positive?
-          add_include('tao/x11/bounded_type_traits_t.h') if idl_type.size.to_i.positive?
           check_idl_type(idl_type)
         end
       end

--- a/ridlbe/c++11/writers/stubheader.rb
+++ b/ridlbe/c++11/writers/stubheader.rb
@@ -473,7 +473,7 @@ module IDL
           add_include('tao/x11/portable_server/servant_forward.h')
         when IDL::Type::AbstractBase
           add_post_include('tao/x11/valuetype/abstract_base.h')
-        when IDL::Type::WString
+        when IDL::Type::WString,
              IDL::Type::WChar
           add_post_include('tao/x11/wstringwchar_ostream.h') if params[:gen_ostream_operators]
         end

--- a/tao/x11/object_ostream.h
+++ b/tao/x11/object_ostream.h
@@ -11,8 +11,7 @@
 #define TAOX11_OBJECT_OSTREAM_H
 
 #include "tao/x11/object_fwd.h"
-
-#include "iostream"
+#include <ostream>
 
 namespace std
 {

--- a/tao/x11/object_ostream.h
+++ b/tao/x11/object_ostream.h
@@ -1,0 +1,29 @@
+/**
+ * @file    object_ostream.h
+ * @author  Marijke Hengstmengel
+ *
+ * @brief   CORBA C++11 Logging module
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+#ifndef TAOX11_OBJECT_OSTREAM_H
+#define TAOX11_OBJECT_OSTREAM_H
+
+#include "tao/x11/object_fwd.h"
+
+#include <sstream>
+#include <cstdlib>
+#include "iostream"
+
+namespace std
+{
+  inline std::ostream&
+        operator<< (std::ostream& _os,
+                    TAOX11_CORBA::object_reference<::TAOX11_NAMESPACE::CORBA::Object> /*_ve*/)
+  {
+    return _os << "CORBA:Object";
+  }
+}
+
+#endif /* TAOX11_OBJECT_OSTREAM_H */

--- a/tao/x11/object_ostream.h
+++ b/tao/x11/object_ostream.h
@@ -12,15 +12,13 @@
 
 #include "tao/x11/object_fwd.h"
 
-#include <sstream>
-#include <cstdlib>
 #include "iostream"
 
 namespace std
 {
   inline std::ostream&
-        operator<< (std::ostream& _os,
-                    TAOX11_CORBA::object_reference<::TAOX11_NAMESPACE::CORBA::Object> /*_ve*/)
+  operator<< (std::ostream& _os,
+              TAOX11_CORBA::object_reference<::TAOX11_NAMESPACE::CORBA::Object> /*_ve*/)
   {
     return _os << "CORBA:Object";
   }

--- a/tao/x11/taox11.mpc
+++ b/tao/x11/taox11.mpc
@@ -295,7 +295,6 @@ project(taox11) : taox11_defaults, taolib {
     bounded_vector_t.h
     cdr_long_double.h
     corba.h
-    corba_ostream.h
     dynamic_adapter.h
     exception.h
     exception_macros.h
@@ -310,6 +309,7 @@ project(taox11) : taox11_defaults, taolib {
     object.h
     object_fwd.h
     object_loader.h
+    object_ostream.h
     object_traits_t.h
     objproxy.h
     orb.h
@@ -339,6 +339,7 @@ project(taox11) : taox11_defaults, taolib {
     valuetype_adapter.h
     versioned_x11_namespace.h
     versionx11.h
+    wstringwchar_ostream.h
   }
 
   Header_Files {

--- a/tao/x11/wstringwchar_ostream.h
+++ b/tao/x11/wstringwchar_ostream.h
@@ -1,5 +1,5 @@
 /**
- * @file    corba_ostream.h
+ * @file    wstringwchar_ostream.h
  * @author  Marijke Hengstmengel
  *
  * @brief   CORBA C++11 Logging module
@@ -7,25 +7,16 @@
  * @copyright Copyright (c) Remedy IT Expertise BV
  */
 
-#ifndef TAOX11_CORBA_OSTREAM_H
-#define TAOX11_CORBA_OSTREAM_H
-
-#include "tao/x11/taox11_export.h"
-#include "tao/x11/corba.h"
+#ifndef TAOX11_WTRINGWCHAR_OSTREAM_H
+#define TAOX11_WTRINGWCHAR_OSTREAM_H
 
 #include <sstream>
 #include <cstdlib>
 #include "iostream"
+#include "ace/ace_wchar.h"
 
 namespace std
 {
-  inline std::ostream&
-        operator<< (std::ostream& _os,
-                    TAOX11_CORBA::object_reference<::TAOX11_NAMESPACE::CORBA::Object> /*_ve*/)
-  {
-    return _os << "CORBA:Object";
-  }
-
   /// std::wstring to ostream insertion
   inline std::ostream&
   operator<< (std::ostream& _os, const std::wstring& _v)
@@ -52,4 +43,4 @@ namespace std
   }
 }
 
-#endif /* TAOX11_CORBA_OSTREAM_H */
+#endif /* TAOX11_WTRINGWCHAR_OSTREAM_H */

--- a/tao/x11/wstringwchar_ostream.h
+++ b/tao/x11/wstringwchar_ostream.h
@@ -10,10 +10,10 @@
 #ifndef TAOX11_WTRINGWCHAR_OSTREAM_H
 #define TAOX11_WTRINGWCHAR_OSTREAM_H
 
-#include <sstream>
+#include <ostream>
 #include <cstdlib>
-#include "iostream"
-#include "ace/ace_wchar.h"
+#include <codecvt>
+#include <locale>
 
 namespace std
 {
@@ -21,7 +21,8 @@ namespace std
   inline std::ostream&
   operator<< (std::ostream& _os, const std::wstring& _v)
   {
-    return _os << "\"" << ACE_Wide_To_Ascii (_v.c_str ()).char_rep () << "\"";
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> conv;
+    return _os << "\"" << conv.to_bytes(_v) << "\"";
   }
 
   /// wchar_t to ostream insertion

--- a/tests/wchar/client.cpp
+++ b/tests/wchar/client.cpp
@@ -1,0 +1,74 @@
+/**
+ * @file    client.cpp
+ * @author  Johnny Willemsen
+ *
+ * @brief   CORBA C++11 client application
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+#include "testC.h"
+#include "testlib/taox11_testlog.h"
+
+int main(int argc, char* argv[])
+{
+  int result = 0;
+  try
+  {
+    IDL::traits<CORBA::ORB>::ref_type orb = CORBA::ORB_init(argc, argv);
+
+    if (orb == nullptr)
+    {
+      TAOX11_TEST_ERROR << "ERROR: CORBA::ORB_init (argc, argv) returned null ORB."
+          << std::endl;
+      return 1;
+    }
+
+    IDL::traits<CORBA::Object>::ref_type obj = orb->string_to_object("file://test.ior");
+
+    if (!obj)
+    {
+      TAOX11_TEST_ERROR << "ERROR: string_to_object(<ior>) returned null reference."
+          << std::endl;
+      return 1;
+    }
+
+    TAOX11_TEST_DEBUG << "retrieved object reference" << std::endl;
+
+    IDL::traits<Test::Hello>::ref_type hello = IDL::traits<Test::Hello>::narrow (obj);
+
+    if (!hello)
+    {
+      TAOX11_TEST_ERROR << "ERROR: IDL::traits<Test::Hello>::narrow (obj) returned null object."
+          << std::endl;
+      return 1;
+    }
+    TAOX11_TEST_DEBUG << "narrowed Hello interface" << std::endl;
+
+    // Test
+    {
+      TAOX11_TEST_DEBUG << "Test wchar get and set." << std::endl;
+      wchar_t const text = hello->getset_wchar (L'H');
+      if (text != L'H')
+      {
+        TAOX11_TEST_ERROR_W << L"ERROR: hello->get_string() returned an unexpected value. "
+          << L"expected <H>, received <" << text << L">" << std::endl;
+        ++result;
+      }
+      TAOX11_TEST_DEBUG_W << L"ostream test wchar: " << text << std::endl;
+    }
+
+    TAOX11_TEST_DEBUG << "shutting down...";
+    hello->shutdown();
+    TAOX11_TEST_DEBUG << std::endl;
+
+    orb->destroy ();
+  }
+  catch (const std::exception& e)
+  {
+    TAOX11_TEST_ERROR << "exception caught: " << e << std::endl;
+    ++result;
+  }
+
+  return result;
+}

--- a/tests/wchar/hello.cpp
+++ b/tests/wchar/hello.cpp
@@ -1,0 +1,35 @@
+/**
+ * @file    hello.cpp
+ * @author  Mark Drijver
+ *
+ * @brief   CORBA C++11 server application
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+
+#include "hello.h"
+#include "testlib/taox11_testlog.h"
+
+Hello::Hello(IDL::traits<CORBA::ORB>::ref_type orb, int& result)
+  : orb_ (std::move(orb))
+  , result_ (result)
+{
+}
+
+wchar_t
+Hello::getset_wchar (wchar_t text)
+{
+  if (text != L'H')
+  {
+    TAOX11_TEST_ERROR_W << L"ERROR: Hello::getset_wchar received an unexpected value. "
+      << L"expected <H>, received <" << text << L">" << std::endl;
+    ++this->result_;
+  }
+  return L'H';
+}
+
+void Hello::shutdown ()
+{
+  this->orb_->shutdown (false);
+}

--- a/tests/wchar/hello.h
+++ b/tests/wchar/hello.h
@@ -1,0 +1,37 @@
+/**
+ * @file    hello.h
+ * @author  Johnny Willemsen
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+#ifndef HELLO_H
+#define HELLO_H
+
+#include "testS.h"
+
+/// Implement the Test::Hello interface
+class Hello final
+  : public virtual CORBA::servant_traits<Test::Hello>::base_type
+{
+public:
+  /// Constructor
+  Hello(IDL::traits<CORBA::ORB>::ref_type orb, int& result);
+
+  // = The skeleton methods
+  wchar_t getset_wchar(wchar_t text) override;
+
+  void shutdown() override;
+
+private:
+  /// Use an ORB reference to convert strings to objects and shutdown
+  /// the application.
+  IDL::traits<CORBA::ORB>::ref_type orb_;
+  int &result_;
+
+  Hello (const Hello&) = delete;
+  Hello (Hello&&) = delete;
+  Hello& operator= (const Hello&) = delete;
+  Hello& operator= (Hello&&) = delete;
+};
+
+#endif /* HELLO_H */

--- a/tests/wchar/run_test.pl
+++ b/tests/wchar/run_test.pl
@@ -1,0 +1,78 @@
+#---------------------------------------------------------------------
+# @file   run_test.pl
+# @author Mark Drijver
+#
+# @copyright Copyright (c) Remedy IT Expertise BV
+#---------------------------------------------------------------------
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+     & eval 'exec perl -S $0 $argv:q'
+     if 0;
+
+# -*- perl -*-
+
+use lib "$ENV{ACE_ROOT}/bin";
+use PerlACE::TestTarget;
+
+$status = 0;
+$debug_level = '0';
+
+foreach $i (@ARGV) {
+    if ($i eq '-debug') {
+        $debug_level = '10';
+    }
+}
+
+my $server = PerlACE::TestTarget::create_target(2) || die "Create target 2 failed\n";
+my $client = PerlACE::TestTarget::create_target(3) || die "Create target 3 failed\n";
+
+my $iorbase = "test.ior";
+my $server_iorfile = $server->LocalFile ($iorbase);
+my $client_iorfile = $client->LocalFile ($iorbase);
+$server->DeleteFile($iorbase);
+$client->DeleteFile($iorbase);
+
+$SV = $server->CreateProcess ("server", "-ORBdebuglevel $debug_level -o $server_iorfile");
+$CL = $client->CreateProcess ("client", "-k file://$client_iorfile");
+$server_status = $SV->Spawn ();
+
+if ($server_status != 0) {
+    print STDERR "ERROR: server returned $server_status\n";
+    exit 1;
+}
+
+if ($server->WaitForFileTimed ($iorbase,
+                               $server->ProcessStartWaitInterval()) == -1) {
+    print STDERR "ERROR: cannot find file <$server_iorfile>\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+if ($server->GetFile ($iorbase) == -1) {
+    print STDERR "ERROR: cannot retrieve file <$server_iorfile>\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+if ($client->PutFile ($iorbase) == -1) {
+    print STDERR "ERROR: cannot set file <$client_iorfile>\n";
+    $SV->Kill (); $SV->TimedWait (1);
+    exit 1;
+}
+
+$client_status = $CL->SpawnWaitKill ($client->ProcessStartWaitInterval());
+
+if ($client_status != 0) {
+    print STDERR "ERROR: client returned $client_status\n";
+    $status = 1;
+}
+
+$server_status = $SV->WaitKill ($server->ProcessStopWaitInterval());
+
+if ($server_status != 0) {
+    print STDERR "ERROR: server returned $server_status\n";
+    $status = 1;
+}
+
+$server->DeleteFile($iorbase);
+$client->DeleteFile($iorbase);
+
+exit $status;

--- a/tests/wchar/server.cpp
+++ b/tests/wchar/server.cpp
@@ -1,0 +1,111 @@
+/**
+ * @file    server.cpp
+ * @author  Mark Drijver
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+#include "hello.h"
+
+#include "testlib/taox11_testlog.h"
+#include <fstream>
+
+int
+main(int argc, ACE_TCHAR *argv[])
+{
+  int result = 0;
+  try
+    {
+      IDL::traits<CORBA::ORB>::ref_type _orb = CORBA::ORB_init (argc, argv);
+
+      if (_orb == nullptr)
+      {
+        TAOX11_TEST_ERROR << "ERROR: CORBA::ORB_init (argc, argv) returned null ORB." << std::endl;
+        return 1;
+      }
+
+      IDL::traits<CORBA::Object>::ref_type obj = _orb->resolve_initial_references ("RootPOA");
+
+      if (!obj)
+      {
+        TAOX11_TEST_ERROR << "ERROR: resolve_initial_references (\"RootPOA\") returned null reference." << std::endl;
+        return 1;
+      }
+
+      TAOX11_TEST_DEBUG << "retrieved RootPOA object reference" << std::endl;
+
+      IDL::traits<PortableServer::POA>::ref_type root_poa = IDL::traits<PortableServer::POA>::narrow (obj);
+
+      if (!root_poa)
+      {
+        TAOX11_TEST_ERROR << "ERROR: IDL::traits<PortableServer::POA>::narrow (obj) returned null object." << std::endl;
+        return 1;
+      }
+
+      TAOX11_TEST_DEBUG << "narrowed POA interface" << std::endl;
+
+      IDL::traits<PortableServer::POAManager>::ref_type poaman = root_poa->the_POAManager ();
+
+      if (!poaman)
+      {
+        TAOX11_TEST_ERROR << "ERROR: root_poa->the_POAManager () returned null object." << std::endl;
+        return 1;
+      }
+
+      CORBA::servant_traits<Test::Hello>::ref_type hello_impl = CORBA::make_reference<Hello> (_orb, result);
+
+      TAOX11_TEST_DEBUG << "created Hello servant" << std::endl;
+
+      PortableServer::ObjectId id = root_poa->activate_object (hello_impl);
+
+      TAOX11_TEST_DEBUG << "activated Hello servant" << std::endl;
+
+      IDL::traits<CORBA::Object>::ref_type hello_obj = root_poa->id_to_reference (id);
+
+      if (hello_obj == nullptr)
+      {
+        TAOX11_TEST_ERROR << "ERROR: root_poa->id_to_reference (id) returned null reference." << std::endl;
+        return 1;
+      }
+
+      IDL::traits<Test::Hello>::ref_type hello = IDL::traits<Test::Hello>::narrow (hello_obj);
+
+      if (hello == nullptr)
+      {
+        TAOX11_TEST_ERROR << "ERROR: IDL::traits<Test::Hello>::narrow (hello_obj) returned null reference." << std::endl;
+        return 1;
+      }
+
+      std::string ior = _orb->object_to_string (hello);
+
+      // Output the IOR to the <ior_output_file>
+      std::ofstream fos("test.ior");
+      if (!fos)
+      {
+        TAOX11_TEST_ERROR << "ERROR: failed to open file 'test.ior'" << std::endl;
+        return 1;
+      }
+      fos << ior;
+      fos.close ();
+
+      TAOX11_TEST_DEBUG << "IOR for Hello servant written to 'test.ior' : " << ior << std::endl;
+
+      poaman->activate ();
+
+      TAOX11_TEST_DEBUG << "starting event loop" << std::endl;
+
+      _orb->run ();
+
+      TAOX11_TEST_DEBUG << "event loop finished" << std::endl;
+
+      root_poa->destroy (true, true);
+
+      _orb->destroy ();
+    }
+  catch (const std::exception& e)
+    {
+      TAOX11_TEST_ERROR << "exception caught: " << e << std::endl;
+      return 1;
+    }
+
+  return result;
+}

--- a/tests/wchar/test.idl
+++ b/tests/wchar/test.idl
@@ -1,0 +1,25 @@
+/**
+ * @file    test.idl
+ * @author  Johnny Willemsen
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+#include "orb.idl"
+
+/// Put the interfaces in a module, to avoid global namespace pollution
+module Test
+{
+  typedef wstring<5> bounded_bar;
+
+  /// A wstring interface
+  interface Hello
+  {
+    /// Get and set a wstring
+    wchar getset_wchar (in wchar text);
+
+    /// A method to shutdown the ORB
+    /// This method is used to simplify the test shutdown process
+    oneway void shutdown ();
+  };
+};

--- a/tests/wchar/wchar.mpc
+++ b/tests/wchar/wchar.mpc
@@ -1,0 +1,31 @@
+// -*- MPC -*-
+
+project(*wchar_gen_Idl): ridl_ostream_defaults {
+  IDL_Files {
+    test.idl
+  }
+  custom_only = 1
+}
+
+project(*wchar_gen_Server): taox11_server {
+  after += *wchar_gen_Idl
+  Source_Files {
+    hello.cpp
+    server.cpp
+  }
+  Source_Files {
+    testC.cpp
+    testS.cpp
+  }
+}
+
+project(*wchar_gen_Client): taox11_client {
+  after += *wchar_gen_Idl
+  Source_Files {
+    client.cpp
+  }
+  Source_Files {
+    testC.cpp
+  }
+}
+


### PR DESCRIPTION
…nd only include the new files when necessary. Added a new unit test which only uses a wchar to check that the correct header is included. Removed usage of ACE for wstring/string conversion