### PR TITLE
Removed ACE trace macros, not used for x11

### DIFF
--- a/examples/log_module/my_log_module_export.h
+++ b/examples/log_module/my_log_module_export.h
@@ -35,26 +35,6 @@
 #  define MY_LOGGER_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* MY_LOGGER_HAS_DLL == 1 */
 
-// Set MY_LOGGER_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (MY_LOGGER_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define MY_LOGGER_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define MY_LOGGER_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !MY_LOGGER_NTRACE */
-
-#if (MY_LOGGER_NTRACE == 1)
-#  define MY_LOGGER_TRACE(X)
-#else /* (MY_LOGGER_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define MY_LOGGER_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (MY_LOGGER_NTRACE == 1) */
-
 #endif /* TEST_LOG_MODULE_EXPORT_H */
 
 // End of auto generated file.

--- a/orbsvcs/orbsvcs/naming_server/taox11_cosnaming_export.h
+++ b/orbsvcs/orbsvcs/naming_server/taox11_cosnaming_export.h
@@ -35,26 +35,6 @@
 #  define TAOX11_COSNAMING_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* TAOX11_COSNAMING_HAS_DLL == 1 */
 
-// Set TAOX11_COSNAMING_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (TAOX11_COSNAMING_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define TAOX11_COSNAMING_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define TAOX11_COSNAMING_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !TAOX11_COSNAMING_NTRACE */
-
-#if (TAOX11_COSNAMING_NTRACE == 1)
-#  define TAOX11_COSNAMING_TRACE(X)
-#else /* (TAOX11_COSNAMING_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define TAOX11_COSNAMING_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (TAOX11_COSNAMING_NTRACE == 1) */
-
 #endif /* TAOX11_COSNAMING_EXPORT_H */
 
 // End of auto generated file.

--- a/tao/x11/anytypecode/taox11_anytypecode_export.h
+++ b/tao/x11/anytypecode/taox11_anytypecode_export.h
@@ -35,26 +35,6 @@
 #  define TAOX11_ANYTYPECODE_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* TAOX11_ANYTYPECODE_HAS_DLL == 1 */
 
-// Set TAOX11_ANYTYPECODE_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (TAOX11_ANYTYPECODE_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define TAOX11_ANYTYPECODE_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define TAOX11_ANYTYPECODE_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !TAOX11_ANYTYPECODE_NTRACE */
-
-#if (TAOX11_ANYTYPECODE_NTRACE == 1)
-#  define TAOX11_ANYTYPECODE_TRACE(X)
-#else /* (TAOX11_ANYTYPECODE_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define TAOX11_ANYTYPECODE_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (TAOX11_ANYTYPECODE_NTRACE == 1) */
-
 #endif /* TAOX11_ANYTYPECODE_EXPORT_H */
 
 // End of auto generated file.

--- a/tao/x11/ior_interceptor/taox11_ior_interceptor_export.h
+++ b/tao/x11/ior_interceptor/taox11_ior_interceptor_export.h
@@ -35,26 +35,6 @@
 #  define TAOX11_IOR_INTERCEPTOR_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* TAOX11_IOR_INTERCEPTOR_HAS_DLL == 1 */
 
-// Set TAOX11_IOR_INTERCEPTOR_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (TAOX11_IOR_INTERCEPTOR_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define TAOX11_IOR_INTERCEPTOR_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define TAOX11_IOR_INTERCEPTOR_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !TAOX11_IOR_INTERCEPTOR_NTRACE */
-
-#if (TAOX11_IOR_INTERCEPTOR_NTRACE == 1)
-#  define TAOX11_IOR_INTERCEPTOR_TRACE(X)
-#else /* (TAOX11_IOR_INTERCEPTOR_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define TAOX11_IOR_INTERCEPTOR_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (TAOX11_IOR_INTERCEPTOR_NTRACE == 1) */
-
 #endif /* TAOX11_IOR_INTERCEPTOR_EXPORT_H */
 
 // End of auto generated file.

--- a/tao/x11/ior_table/taox11_ior_table_export.h
+++ b/tao/x11/ior_table/taox11_ior_table_export.h
@@ -37,26 +37,6 @@
 #  define TAOX11_IOR_TABLE_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* TAOX11_IOR_TABLE_HAS_DLL == 1 */
 
-// Set TAOX11_IOR_TABLE_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (TAOX11_IOR_TABLE_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define TAOX11_IOR_TABLE_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define TAOX11_IOR_TABLE_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !TAOX11_IOR_TABLE_NTRACE */
-
-#if (TAOX11_IOR_TABLE_NTRACE == 1)
-#  define TAOX11_IOR_TABLE_TRACE(X)
-#else /* (TAOX11_IOR_TABLE_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define TAOX11_IOR_TABLE_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (TAOX11_IOR_TABLE_NTRACE == 1) */
-
 #endif /* TAOX11_IOR_TABLE_EXPORT_H */
 
 // End of auto generated file.

--- a/tao/x11/logger/x11_logger_export.h
+++ b/tao/x11/logger/x11_logger_export.h
@@ -37,26 +37,6 @@
 #  define X11_LOGGER_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* X11_LOGGER_HAS_DLL == 1 */
 
-// Set X11_LOGGER_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (X11_LOGGER_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define X11_LOGGER_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define X11_LOGGER_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !X11_LOGGER_NTRACE */
-
-#if (X11_LOGGER_NTRACE == 1)
-#  define X11_LOGGER_TRACE(X)
-#else /* (X11_LOGGER_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define X11_LOGGER_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (X11_LOGGER_NTRACE == 1) */
-
 #endif /* X11_LOGGER_EXPORT_H */
 
 // End of auto generated file.

--- a/tao/x11/messaging/taox11_messaging_export.h
+++ b/tao/x11/messaging/taox11_messaging_export.h
@@ -37,26 +37,6 @@
 #  define TAOX11_MESSAGING_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* TAOX11_MESSAGING_HAS_DLL == 1 */
 
-// Set TAOX11_MESSAGING_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (TAOX11_MESSAGING_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define TAOX11_MESSAGING_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define TAOX11_MESSAGING_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !TAOX11_MESSAGING_NTRACE */
-
-#if (TAOX11_MESSAGING_NTRACE == 1)
-#  define TAOX11_MESSAGING_TRACE(X)
-#else /* (TAOX11_MESSAGING_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define TAOX11_MESSAGING_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (TAOX11_MESSAGING_NTRACE == 1) */
-
 #endif /* TAOX11_MESSAGING_EXPORT_H */
 
 // End of auto generated file.

--- a/tao/x11/ort/taox11_ort_export.h
+++ b/tao/x11/ort/taox11_ort_export.h
@@ -35,26 +35,6 @@
 #  define TAOX11_OBJREF_TEMPLATE_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* TAOX11_OBJREF_TEMPLATE_HAS_DLL == 1 */
 
-// Set TAOX11_OBJREF_TEMPLATE_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (TAOX11_OBJREF_TEMPLATE_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define TAOX11_OBJREF_TEMPLATE_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define TAOX11_OBJREF_TEMPLATE_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !TAOX11_OBJREF_TEMPLATE_NTRACE */
-
-#if (TAOX11_OBJREF_TEMPLATE_NTRACE == 1)
-#  define TAOX11_OBJREF_TEMPLATE_TRACE(X)
-#else /* (TAOX11_OBJREF_TEMPLATE_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define TAOX11_OBJREF_TEMPLATE_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (TAOX11_OBJREF_TEMPLATE_NTRACE == 1) */
-
 #endif /* TAOX11_OBJREF_TEMPLATE_EXPORT_H */
 
 // End of auto generated file.

--- a/tao/x11/pi/taox11_pi_export.h
+++ b/tao/x11/pi/taox11_pi_export.h
@@ -37,26 +37,6 @@
 #  define TAOX11_PI_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* TAOX11_PI_HAS_DLL == 1 */
 
-// Set TAOX11_PI_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (TAOX11_PI_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define TAOX11_PI_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define TAOX11_PI_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !TAOX11_PI_NTRACE */
-
-#if (TAOX11_PI_NTRACE == 1)
-#  define TAOX11_PI_TRACE(X)
-#else /* (TAOX11_PI_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define TAOX11_PI_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (TAOX11_PI_NTRACE == 1) */
-
 #endif /* TAOX11_PI_EXPORT_H */
 
 // End of auto generated file.

--- a/tao/x11/pi_server/taox11_pi_server_export.h
+++ b/tao/x11/pi_server/taox11_pi_server_export.h
@@ -35,26 +35,6 @@
 #  define TAOX11_PI_SERVER_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* TAOX11_PI_SERVER_HAS_DLL == 1 */
 
-// Set TAOX11_PI_SERVER_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (TAOX11_PI_SERVER_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define TAOX11_PI_SERVER_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define TAOX11_PI_SERVER_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !TAOX11_PI_SERVER_NTRACE */
-
-#if (TAOX11_PI_SERVER_NTRACE == 1)
-#  define TAOX11_PI_SERVER_TRACE(X)
-#else /* (TAOX11_PI_SERVER_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define TAOX11_PI_SERVER_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (TAOX11_PI_SERVER_NTRACE == 1) */
-
 #endif /* TAOX11_PI_SERVER_EXPORT_H */
 
 // End of auto generated file.

--- a/tao/x11/portable_server/taox11_portableserver_export.h
+++ b/tao/x11/portable_server/taox11_portableserver_export.h
@@ -37,26 +37,6 @@
 #  define TAOX11_PORTABLESERVER_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* TAOX11_PORTABLESERVER_HAS_DLL == 1 */
 
-// Set TAOX11_PORTABLESERVER_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (TAOX11_PORTABLESERVER_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define TAOX11_PORTABLESERVER_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define TAOX11_PORTABLESERVER_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !TAOX11_PORTABLESERVER_NTRACE */
-
-#if (TAOX11_PORTABLESERVER_NTRACE == 1)
-#  define TAOX11_PORTABLESERVER_TRACE(X)
-#else /* (TAOX11_PORTABLESERVER_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define TAOX11_PORTABLESERVER_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (TAOX11_PORTABLESERVER_NTRACE == 1) */
-
 #endif /* TAOX11_PORTABLESERVER_EXPORT_H */
 
 // End of auto generated file.

--- a/tao/x11/taox11_export.h
+++ b/tao/x11/taox11_export.h
@@ -37,26 +37,6 @@
 #  define TAOX11_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* TAOX11_HAS_DLL == 1 */
 
-// Set TAOX11_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (TAOX11_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define TAOX11_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define TAOX11_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !TAOX11_NTRACE */
-
-#if (TAOX11_NTRACE == 1)
-#  define TAOX11_TRACE(X)
-#else /* (TAOX11_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define TAOX11_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (TAOX11_NTRACE == 1) */
-
 #endif /* TAOX11_EXPORT_H */
 
 // End of auto generated file.

--- a/tao/x11/valuetype/taox11_valuetype_export.h
+++ b/tao/x11/valuetype/taox11_valuetype_export.h
@@ -37,26 +37,6 @@
 #  define TAOX11_VALUETYPE_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
 #endif /* TAOX11_VALUETYPE_HAS_DLL == 1 */
 
-// Set TAOX11_VALUETYPE_NTRACE = 0 to turn on library specific tracing even if
-// tracing is turned off for ACE.
-#if !defined (TAOX11_VALUETYPE_NTRACE)
-#  if (ACE_NTRACE == 1)
-#    define TAOX11_VALUETYPE_NTRACE 1
-#  else /* (ACE_NTRACE == 1) */
-#    define TAOX11_VALUETYPE_NTRACE 0
-#  endif /* (ACE_NTRACE == 1) */
-#endif /* !TAOX11_VALUETYPE_NTRACE */
-
-#if (TAOX11_VALUETYPE_NTRACE == 1)
-#  define TAOX11_VALUETYPE_TRACE(X)
-#else /* (TAOX11_VALUETYPE_NTRACE == 1) */
-#  if !defined (ACE_HAS_TRACE)
-#    define ACE_HAS_TRACE
-#  endif /* ACE_HAS_TRACE */
-#  define TAOX11_VALUETYPE_TRACE(X) ACE_TRACE_IMPL(X)
-#  include "ace/Trace.h"
-#endif /* (TAOX11_VALUETYPE_NTRACE == 1) */
-
 #endif /* TAOX11_VALUETYPE_EXPORT_H */
 
 // End of auto generated file.

--- a/tao/x11/versioned_x11_namespace.h
+++ b/tao/x11/versioned_x11_namespace.h
@@ -10,11 +10,6 @@
 #ifndef TAOX11_VERSIONED_X11_NAMESPACE_H
 #define TAOX11_VERSIONED_X11_NAMESPACE_H
 
-#if !defined (TAO_ORBCONF_H) && !defined (ACE_CONFIG_MACROS_H)
-# error This header is only meant to be included after "tao/orbconf.h".
-#endif  /* !TAO_ORBCONF_H */
-
-
 #if !defined (TAOX11_HAS_VERSIONED_NAMESPACE)
 # define TAOX11_HAS_VERSIONED_NAMESPACE 0
 #endif  /* !TAOX11_HAS_VERSIONED_NAMESPACE */


### PR DESCRIPTION
    * examples/log_module/my_log_module_export.h:
    * orbsvcs/orbsvcs/naming_server/taox11_cosnaming_export.h:
    * tao/x11/anytypecode/taox11_anytypecode_export.h:
    * tao/x11/ior_interceptor/taox11_ior_interceptor_export.h:
    * tao/x11/ior_table/taox11_ior_table_export.h:
    * tao/x11/logger/x11_logger_export.h:
    * tao/x11/messaging/taox11_messaging_export.h:
    * tao/x11/ort/taox11_ort_export.h:
    * tao/x11/pi/taox11_pi_export.h:
    * tao/x11/pi_server/taox11_pi_server_export.h:
    * tao/x11/portable_server/taox11_portableserver_export.h:
    * tao/x11/taox11_export.h:
    * tao/x11/valuetype/taox11_valuetype_export.h:
    * tao/x11/versioned_x11_namespace.h: