### PR TITLE
Simplified valuebox/valuetype generation by using C++17 static inline…

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/valuebox_def.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuebox_def.erb
@@ -29,7 +29,7 @@ protected:
   template <typename _Tp1, typename, typename ...Args>
   friend constexpr TAOX11_CORBA::valuetype_reference<_Tp1> TAOX11_CORBA::make_reference(Args&& ...args);
 
-  static const std::string __<%= cxxname.downcase %>_repository_id;
+  static inline const std::string __<%= cxxname.downcase %>_repository_id {"<%= repository_id %>"};
 
   <%= cxxname %> () = default;
   <%= cxxname %> (const <%= cxxname %>&) = default;

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_pre.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_pre.erb
@@ -47,7 +47,7 @@ protected:
 % end
   using _shared_ptr_type = std::shared_ptr<<%= cxxname %>>;
 
-  static const std::string __<%= cxxname.downcase %>_repository_id;
+  static inline const std::string __<%= cxxname.downcase %>_repository_id {"<%= repository_id %>"};
 
 % if is_truncatable?
   <%= cxxname %> ();

--- a/ridlbe/c++11/templates/cli/src/valuebox_def.erb
+++ b/ridlbe/c++11/templates/cli/src/valuebox_def.erb
@@ -1,7 +1,5 @@
 
 // generated from <%= ridl_template_path %>
-const std::string <%= scoped_cxxname %>::__<%= cxxname.downcase %>_repository_id {"<%= repository_id %>"};
-
 TAOX11_IDL::traits<TAOX11_CORBA::ValueBase>::ref_type
 <%= scoped_cxxname %>::_copy_value () const
 {

--- a/ridlbe/c++11/templates/cli/src/valuetype_pre.erb
+++ b/ridlbe/c++11/templates/cli/src/valuetype_pre.erb
@@ -51,8 +51,6 @@ bool
   return true;
 }
 
-const std::string <%= cxxname %>::__<%= cxxname.downcase %>_repository_id {"<%= repository_id %>"};
-
 const std::string&
 <%= cxxname %>::_obv_repository_id () const
 {


### PR DESCRIPTION
… constants

    * ridlbe/c++11/templates/cli/hdr/valuebox_def.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_pre.erb:
    * ridlbe/c++11/templates/cli/src/valuebox_def.erb:
    * ridlbe/c++11/templates/cli/src/valuetype_pre.erb: