### PR TITLE
Removed generation of not used repo_id

### DIFF
--- a/ridlbe/c++11/templates/cli/src/ami/interface_amic_pre.erb
+++ b/ridlbe/c++11/templates/cli/src/ami/interface_amic_pre.erb
@@ -1,3 +1,0 @@
-
-// generated from <%= ridl_template_path %>
-static const std::string <%= amic_scoped_cxxname.gsub('::', '_').downcase %>_repo_id_ {"<%= repository_id %>"};

--- a/ridlbe/c++11/writers/amistubsource.rb
+++ b/ridlbe/c++11/writers/amistubsource.rb
@@ -727,8 +727,6 @@ module IDL
 
       def enter_interface(node)
         return unless needs_ami_generation?(node)
-
-        ami_interface.visit_amic_pre(node)
       end
 
       def leave_interface(node)


### PR DESCRIPTION
    * ridlbe/c++11/templates/cli/src/ami/interface_amic_pre.erb:
      Deleted.

    * ridlbe/c++11/writers/amistubsource.rb: