### PR TITLE
Update gcc-13 config

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,12 +75,11 @@ jobs:
             CXX: g++-12
             ruby: '3.2'
             PackageDeps: g++-12
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             CC: gcc-13
             CXX: g++-13
             ruby: '3.2'
             PackageDeps: g++-13
-            Repo: ppa:ubuntu-toolchain-r/test
           - os: ubuntu-22.04
             CC: gcc-10
             CXX: g++-10

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,6 +80,7 @@ jobs:
             CXX: g++-13
             ruby: '3.2'
             PackageDeps: g++-13
+            Repo: ppa:ubuntu-toolchain-r/test
           - os: ubuntu-22.04
             CC: gcc-10
             CXX: g++-10


### PR DESCRIPTION
gcc-13 has been removed from ubuntu-22.04, see https://github.com/actions/runner-images/issues/9866