### PR TITLE
Use override instead of virtual for destructors

### DIFF
--- a/tao/x11/anyinsert_adapter.h
+++ b/tao/x11/anyinsert_adapter.h
@@ -52,7 +52,7 @@ namespace TAOX11_NAMESPACE
     : public ACE_Service_Object
   {
   public:
-    virtual ~AnyInsertAdapter () = default;
+    ~AnyInsertAdapter () override = default;
 
 #define TAOX11_SYSTEM_EXCEPTION(name) \
     virtual void insert_into_any (CORBA::Any * any, const CORBA::name &) = 0; \

--- a/tao/x11/anytypecode/any_basic_impl.h
+++ b/tao/x11/anytypecode/any_basic_impl.h
@@ -31,7 +31,7 @@ namespace TAOX11_NAMESPACE
     Any_Basic_Impl (CORBA::typecode_reference,
                     void *value);
 
-    virtual ~Any_Basic_Impl () = default;
+    ~Any_Basic_Impl () override = default;
 
     static void insert (CORBA::Any &,
                         CORBA::typecode_reference,

--- a/tao/x11/anytypecode/any_basic_impl_t.h
+++ b/tao/x11/anytypecode/any_basic_impl_t.h
@@ -37,7 +37,7 @@ namespace TAOX11_NAMESPACE
 
     Any_Basic_Impl_T (CORBA::typecode_reference,
                       value_type val);
-    virtual ~Any_Basic_Impl_T () = default;
+    ~Any_Basic_Impl_T () override = default;
 
     static void insert (CORBA::Any &,
                         CORBA::typecode_reference,
@@ -75,7 +75,7 @@ namespace TAOX11_NAMESPACE
 
     Any_Object_Impl_T (CORBA::typecode_reference,
                        value_type val);
-    virtual ~Any_Object_Impl_T () = default;
+    ~Any_Object_Impl_T () override = default;
 
     static void insert (CORBA::Any &,
                         CORBA::typecode_reference,
@@ -104,7 +104,7 @@ namespace TAOX11_NAMESPACE
 
     Any_Value_Impl_T (CORBA::typecode_reference,
                       value_type val);
-    virtual ~Any_Value_Impl_T () = default;
+    ~Any_Value_Impl_T () override = default;
 
     bool marshal_type (TAO_OutputCDR &) override;
 
@@ -133,9 +133,8 @@ namespace TAOX11_NAMESPACE
     using ref_type = std::shared_ptr<impl_type>;
     using value_type = typename TRAITS::value_type;
 
-    Any_AbstractBase_Impl_T (CORBA::typecode_reference,
-                      value_type val);
-    virtual ~Any_AbstractBase_Impl_T () = default;
+    Any_AbstractBase_Impl_T (CORBA::typecode_reference, value_type val);
+    ~Any_AbstractBase_Impl_T () override = default;
 
     static void insert (CORBA::Any &,
                         CORBA::typecode_reference,

--- a/tao/x11/anytypecode/any_dual_impl_t.h
+++ b/tao/x11/anytypecode/any_dual_impl_t.h
@@ -42,7 +42,7 @@ namespace TAOX11_NAMESPACE
     Any_Dual_Impl_T (CORBA::typecode_reference,
                      const value_type &);
     Any_Dual_Impl_T (CORBA::typecode_reference);
-    virtual ~Any_Dual_Impl_T () = default;
+    ~Any_Dual_Impl_T () override = default;
 
     static void insert (CORBA::Any &,
                         CORBA::typecode_reference,

--- a/tao/x11/anytypecode/typecode_case_t.h
+++ b/tao/x11/anytypecode/typecode_case_t.h
@@ -99,7 +99,7 @@ namespace TAOX11_NAMESPACE
         , label_ (member_label)
       {
       }
-      virtual ~Case_T () = default;
+      ~Case_T () override = default;
 
 
       /**

--- a/tao/x11/anytypecode/typecode_impl.h
+++ b/tao/x11/anytypecode/typecode_impl.h
@@ -53,7 +53,7 @@ namespace TAOX11_NAMESPACE
         : TypeCode (),
           static_ (true)
       { this->u_.tcref_ = const_cast<TAO_CORBA::TypeCode_ptr*> (std::addressof(tc)); }
-      virtual ~TypeCode_impl ();
+      ~TypeCode_impl () override;
 
       bool _is_a (const std::string& local_type_id) override;
 

--- a/tao/x11/basic_argument_t.h
+++ b/tao/x11/basic_argument_t.h
@@ -33,7 +33,7 @@ namespace TAOX11_NAMESPACE
     In_Basic_Argument_T (S const & x)
       : x_ (x) {}
 
-    TAO_CORBA::Boolean marshal (TAO_OutputCDR &cdr ) override;
+    TAO_CORBA::Boolean marshal (TAO_OutputCDR &cdr) override;
 #if TAO_HAS_INTERCEPTORS == 1
     void interceptor_value (TAO_CORBA::Any *any) const override;
 #endif /* TAO_HAS_INTERCEPTORS == 1 */
@@ -58,7 +58,7 @@ namespace TAOX11_NAMESPACE
     In_Basic_Clonable_Argument_T (S const & x)
       : In_Basic_Argument_T<S, Insert_Policy> (x)
       , is_clone_ (false) {}
-    virtual ~In_Basic_Clonable_Argument_T ();
+    ~In_Basic_Clonable_Argument_T () override;
 
     TAO_TAO::Argument* clone () override;
 

--- a/tao/x11/dynamic_any/dyn_common.h
+++ b/tao/x11/dynamic_any/dyn_common.h
@@ -37,7 +37,7 @@ namespace TAOX11_NAMESPACE
       TAOX11_DynCommon (bool allow_truncation);
 
       /// Destructor.
-      virtual ~TAOX11_DynCommon () = default;
+      ~TAOX11_DynCommon () override = default;
 
       IDL::traits<CORBA::TypeCode>::ref_type
       type () override;

--- a/tao/x11/ior_interceptor/ior_info.h
+++ b/tao/x11/ior_interceptor/ior_info.h
@@ -24,7 +24,7 @@ namespace TAOX11_NAMESPACE
     public:
       explicit IORInfo (TAO_PI::IORInfo_ptr iorinf);
 
-      virtual ~IORInfo () = default;
+      ~IORInfo () override = default;
 
       IDL::traits<CORBA::Policy>::ref_type
       get_effective_policy (CORBA::PolicyType type) override;

--- a/tao/x11/log.h
+++ b/tao/x11/log.h
@@ -52,7 +52,7 @@ namespace TAOX11_NAMESPACE
     : public x11_logger::Log_Module
     {
     public:
-      virtual ~TAOX11_Log_Module();
+      ~TAOX11_Log_Module() override;
 
       static TAOX11_Log_Module* getInstance();
 

--- a/tao/x11/logger/log_base.h
+++ b/tao/x11/logger/log_base.h
@@ -177,7 +177,7 @@ namespace x11_logger
     : public x11_logger::Log_Module
   {
   public:
-    virtual ~TAOX11_Test_Log_Module ();
+    ~TAOX11_Test_Log_Module () override;
 
     static TAOX11_Test_Log_Module* getInstance();
 

--- a/tao/x11/logger/log_type.h
+++ b/tao/x11/logger/log_type.h
@@ -108,7 +108,7 @@ namespace x11_logger
     {
       this->log_module_ = LOG_MODULE::getInstance ();
     }
-    virtual ~Log_Type_T ()
+    ~Log_Type_T () override
     {
       if (this == Log_Type_T<LOG_MODULE>::reference_)
       {

--- a/tao/x11/logger/logstream_t.h
+++ b/tao/x11/logger/logstream_t.h
@@ -50,7 +50,7 @@ namespace x11_logger
     log_buffer_t (typename log_buffer_t<CH, TR>::logprio_type,
                   typename std::basic_ios<CH, TR>::openmode mode);
 
-    virtual ~log_buffer_t () = default;
+    ~log_buffer_t () override = default;
 
     void log_module (const Log_Type& lm)
     { this->lm_typeref_ = lm.get_reference (); }

--- a/tao/x11/long_double_argument_t.h
+++ b/tao/x11/long_double_argument_t.h
@@ -60,7 +60,7 @@ namespace TAOX11_NAMESPACE
   public:
     In_Basic_Clonable_Argument_T (long double const & x)
       : In_Basic_Argument_T<long double, Insert_Policy> (x) {}
-    virtual ~In_Basic_Clonable_Argument_T ();
+    ~In_Basic_Clonable_Argument_T () override;
 
     TAO_TAO::Argument* clone () override;
 

--- a/tao/x11/messaging/exception_holder_i.h
+++ b/tao/x11/messaging/exception_holder_i.h
@@ -42,7 +42,7 @@ namespace TAOX11_NAMESPACE
         const ::TAOX11_NAMESPACE::Dynamic::ExceptionList& exc_list) override;
 
   protected:
-    virtual ~ExceptionHolder_i () = default;
+    ~ExceptionHolder_i () override = default;
 
   private:
     ExceptionHolder_i () = delete;

--- a/tao/x11/object.h
+++ b/tao/x11/object.h
@@ -275,7 +275,7 @@ namespace TAOX11_NAMESPACE
       LocalObject& operator=(const LocalObject&) = delete;
       LocalObject& operator=(LocalObject&&) = delete;
 
-      virtual ~LocalObject ();
+      ~LocalObject () override;
     };
 
   } // namespace CORBA

--- a/tao/x11/object_loader.h
+++ b/tao/x11/object_loader.h
@@ -35,7 +35,7 @@ namespace TAOX11_NAMESPACE
   {
   public:
     /// The destructor
-    virtual ~Object_Loader ();
+    ~Object_Loader () override;
 
     /**
      * Create and activate a new object into the orb.

--- a/tao/x11/orb.h
+++ b/tao/x11/orb.h
@@ -339,7 +339,7 @@ namespace TAOX11_NAMESPACE
           const std::string& orb_name = std::string ());
 
     protected:
-      virtual ~ORB ();
+      ~ORB () override;
 
 #if !defined(CORBA_E_MICRO)
       ValueFactoryManagerAdapter *valuefactory_manager ();

--- a/tao/x11/pi/client_request_info.h
+++ b/tao/x11/pi/client_request_info.h
@@ -27,7 +27,7 @@ namespace TAOX11_NAMESPACE
     public:
       explicit ClientRequestInfo (TAO_PI::ClientRequestInfo_ptr reqinf);
 
-      virtual ~ClientRequestInfo () = default;
+      ~ClientRequestInfo () override = default;
 
       IDL::traits<TAOX11_NAMESPACE::CORBA::Object>::ref_type
       target () override;

--- a/tao/x11/pi/orb_init_info.h
+++ b/tao/x11/pi/orb_init_info.h
@@ -31,7 +31,7 @@ namespace TAOX11_NAMESPACE
     public:
       explicit ORBInitInfo (TAO_PI::ORBInitInfo_3_1_ptr orbii);
 
-      virtual ~ORBInitInfo () = default;
+      ~ORBInitInfo () override = default;
 
       ::TAOX11_NAMESPACE::CORBA::StringSeq arguments () override;
 

--- a/tao/x11/pi/orb_initializer_registry.cpp
+++ b/tao/x11/pi/orb_initializer_registry.cpp
@@ -29,7 +29,7 @@ namespace TAOX11_NAMESPACE
           IDL::traits<PortableInterceptor::ORBInitializer>::ref_type init)
         : init_ (std::move (init))
       {}
-      virtual ~ORBInitializer_proxy () = default;
+      ~ORBInitializer_proxy () override = default;
 
       /// The pre-initialization hook.
       void pre_init (TAO_PI::ORBInitInfo_ptr info) override;

--- a/tao/x11/pi/pi_current.h
+++ b/tao/x11/pi/pi_current.h
@@ -25,7 +25,7 @@ namespace TAOX11_NAMESPACE
     public:
       explicit PICurrent (TAO_PI::Current_ptr pic);
 
-      virtual ~PICurrent () = default;
+      ~PICurrent () override = default;
 
       CORBA::Any
       get_slot (PortableInterceptor::SlotId id) override;

--- a/tao/x11/pi/request_info.h
+++ b/tao/x11/pi/request_info.h
@@ -25,7 +25,7 @@ namespace TAOX11_NAMESPACE
     public:
       explicit RequestInfo (TAO_PI::RequestInfo_ptr reqinf);
 
-      virtual ~RequestInfo () = default;
+      ~RequestInfo () override = default;
 
       uint32_t request_id () override;
 

--- a/tao/x11/pi_server/server_request_info.h
+++ b/tao/x11/pi_server/server_request_info.h
@@ -27,7 +27,7 @@ namespace TAOX11_NAMESPACE
     public:
       explicit ServerRequestInfo (TAO_PI::ServerRequestInfo_ptr reqinf);
 
-      virtual ~ServerRequestInfo () = default;
+      ~ServerRequestInfo () override = default;
 
       bool _is_a (const std::string& local_type_id) override;
 

--- a/tao/x11/portable_server/portableserver_impl.h
+++ b/tao/x11/portable_server/portableserver_impl.h
@@ -160,7 +160,7 @@ namespace TAOX11_NAMESPACE {
       POA_proxy& _proxy ();
 
     protected:
-      virtual ~POA_impl () = default;
+      ~POA_impl () override = default;
 
     private:
       template <typename _Tp1, typename, typename ...Args>
@@ -209,7 +209,7 @@ namespace TAOX11_NAMESPACE {
       POAManager_proxy& _proxy ();
 
     protected:
-      virtual ~POAManager_impl () = default;
+      ~POAManager_impl () override = default;
 
     private:
       template <typename _Tp1, typename, typename ...Args>
@@ -250,7 +250,7 @@ namespace TAOX11_NAMESPACE {
       POAManagerFactory_proxy& _proxy ();
 
     protected:
-      virtual ~POAManagerFactory_impl () = default;
+      ~POAManagerFactory_impl () override = default;
 
     private:
       template <typename _Tp1, typename, typename ...Args>
@@ -289,7 +289,7 @@ namespace TAOX11_NAMESPACE {
       POA_Current_proxy& _proxy ();
 
     protected:
-      virtual ~POA_Current_impl () = default;
+      ~POA_Current_impl () override = default;
 
     private:
       template <typename _Tp1, typename, typename ...Args>

--- a/tao/x11/portable_server/servant_proxy.h
+++ b/tao/x11/portable_server/servant_proxy.h
@@ -33,7 +33,7 @@ namespace TAOX11_NAMESPACE {
   public:
     using skel_ref_type = std::shared_ptr<TAOX11_NAMESPACE::PortableServer::Servant>;
 
-    virtual ~Servant_proxy () = default;
+    ~Servant_proxy () override = default;
 
     void _add_ref () final;
 

--- a/tao/x11/portable_server/upcall_command.h
+++ b/tao/x11/portable_server/upcall_command.h
@@ -34,7 +34,7 @@ namespace TAOX11_NAMESPACE
     Upcall_Command (std::function<void()> execute_function);
 
     /// Destructor.
-    virtual ~Upcall_Command () = default;
+    ~Upcall_Command () override = default;
 
     /// Calls the execute_function catching/wrapping any user exceptions.
     void execute () override;

--- a/tao/x11/special_basic_argument_t.h
+++ b/tao/x11/special_basic_argument_t.h
@@ -62,7 +62,7 @@ namespace TAOX11_NAMESPACE
     In_Special_Basic_Clonable_Argument_T (S const &x)
       : In_Special_Basic_Argument_T<S, to_S, from_S, Insert_Policy> (x)
       , is_clone_ (false) {}
-    virtual ~In_Special_Basic_Clonable_Argument_T ();
+    ~In_Special_Basic_Clonable_Argument_T () override;
 
     TAO_TAO::Argument* clone () override;
 

--- a/tao/x11/typecodefactory/typecodefactory_adapter_impl.h
+++ b/tao/x11/typecodefactory/typecodefactory_adapter_impl.h
@@ -24,7 +24,7 @@ namespace TAOX11_NAMESPACE
   {
   public:
     TypeCodeFactory_Adapter_Impl ();
-    virtual ~TypeCodeFactory_Adapter_Impl ();
+    ~TypeCodeFactory_Adapter_Impl () override;
 
     CORBA::object_reference<CORBA::TypeCode> create_struct_tc (
           const std::string &id,

--- a/tao/x11/typecodefactory/typecodefactory_i.h
+++ b/tao/x11/typecodefactory/typecodefactory_i.h
@@ -22,21 +22,20 @@
 
 namespace TAOX11_NAMESPACE
 {
-
+  /**
+   * @class TypeCodeFactory_i
+   *
+   * @brief TypeCodeFactory_i.
+   *
+   * Implementation of the CORBA::TypeCodeFactory interface
+   */
   class TAOX11_TYPECODEFACTORY_Export TypeCodeFactory_i
     : public virtual CORBA::TypeCodeFactory,
       public virtual CORBA::LocalObject
   {
-/**
- * @class TypeCodeFactory_i
- *
- * @brief TypeCodeFactory_i.
- *
- * Implementation of the CORBA::TypeCodeFactory interface
- */
   public:
     TypeCodeFactory_i () = default;
-    virtual ~TypeCodeFactory_i () = default;
+    ~TypeCodeFactory_i () override = default;
 
     CORBA::object_reference<CORBA::TypeCode> create_struct_tc (
           const std::string &id,

--- a/tao/x11/valuetype/abstractbase_proxy.h
+++ b/tao/x11/valuetype/abstractbase_proxy.h
@@ -48,7 +48,7 @@ namespace TAOX11_NAMESPACE
                         TAO_CORBA::Boolean,
                         TAO_Abstract_ServantBase *);
 
-    virtual ~Abstractbase_proxy () = default;
+    ~Abstractbase_proxy () override = default;
   };
 
 } // namespace TAOX11_NAMESPACE


### PR DESCRIPTION
    * tao/x11/anyinsert_adapter.h:
    * tao/x11/anytypecode/any_basic_impl.h:
    * tao/x11/anytypecode/any_basic_impl_t.h:
    * tao/x11/anytypecode/any_dual_impl_t.h:
    * tao/x11/anytypecode/typecode_case_t.h:
    * tao/x11/anytypecode/typecode_impl.h:
    * tao/x11/basic_argument_t.h:
    * tao/x11/dynamic_any/dyn_common.h:
    * tao/x11/ior_interceptor/ior_info.h:
    * tao/x11/log.h:
    * tao/x11/logger/log_base.h:
    * tao/x11/logger/log_type.h:
    * tao/x11/logger/logstream_t.h:
    * tao/x11/long_double_argument_t.h:
    * tao/x11/messaging/exception_holder_i.h:
    * tao/x11/object.h:
    * tao/x11/object_loader.h:
    * tao/x11/orb.h:
    * tao/x11/pi/client_request_info.h:
    * tao/x11/pi/orb_init_info.h:
    * tao/x11/pi/orb_initializer_registry.cpp:
    * tao/x11/pi/pi_current.h:
    * tao/x11/pi/request_info.h:
    * tao/x11/pi_server/server_request_info.h:
    * tao/x11/portable_server/portableserver_impl.h:
    * tao/x11/portable_server/servant_proxy.h:
    * tao/x11/portable_server/upcall_command.h:
    * tao/x11/special_basic_argument_t.h:
    * tao/x11/typecodefactory/typecodefactory_adapter_impl.h:
    * tao/x11/typecodefactory/typecodefactory_i.h:
    * tao/x11/valuetype/abstractbase_proxy.h: