### PR TITLE
Simplify code generation by using std::underlying_type_t

### DIFF
--- a/ridlbe/c++11/templates/cli/src/bitmask_cdr.erb
+++ b/ridlbe/c++11/templates/cli/src/bitmask_cdr.erb
@@ -11,7 +11,7 @@ TAO_CORBA::Boolean operator<< (TAO_OutputCDR &strm, const <%= scoped_cxxname %> 
 
 TAO_CORBA::Boolean operator>> (TAO_InputCDR &strm, <%= scoped_cxxname %> &_tao_bitmask)
 {
-  <%= bitbound.cxx_member_type %> _tao_temp <%= bitbound.value_initializer %>;
+  std::underlying_type_t<<%= scoped_cxxname %>> _tao_temp <%= bitbound.value_initializer %>;
   bool const _tao_success = strm >> <%= bitbound.cdr_to_fmt % "_tao_temp" %>;
 
   if (_tao_success)

--- a/ridlbe/c++11/templates/cli/src/bitset_cdr.erb
+++ b/ridlbe/c++11/templates/cli/src/bitset_cdr.erb
@@ -9,7 +9,7 @@ TAO_CORBA::Boolean operator<< (TAO_OutputCDR &/*strm*/, const <%= scoped_cxxname
 TAO_CORBA::Boolean operator>> (TAO_InputCDR &/*strm*/, <%= scoped_cxxname %> & /*_tao_bitset*/)
 {
   return true;
-%#  <%= bitbound.cxx_member_type %> _tao_temp <%= bitbound.value_initializer %>;
+%#  std::underlying_type_t<<%= scoped_cxxname %>> _tao_temp <%= bitbound.value_initializer %>;
 %#  bool const _tao_success = strm >> <%= bitbound.cdr_to_fmt % "_tao_temp" %>;
 %#
 %#  if (_tao_success)

--- a/ridlbe/c++11/templates/cli/src/enum_cdr.erb
+++ b/ridlbe/c++11/templates/cli/src/enum_cdr.erb
@@ -11,7 +11,7 @@ TAO_CORBA::Boolean operator<< (TAO_OutputCDR &strm, const <%= scoped_cxxname %> 
 
 TAO_CORBA::Boolean operator>> (TAO_InputCDR &strm, <%= scoped_cxxname %> &_tao_enumerator)
 {
-  <%= bitbound.cxx_member_type %> _tao_temp <%= bitbound.value_initializer %>;
+  std::underlying_type_t<<%= scoped_cxxname %>> _tao_temp <%= bitbound.value_initializer %>;
   bool const _tao_success = strm >> <%= bitbound.cdr_to_fmt % "_tao_temp" %>;
 
   if (_tao_success)


### PR DESCRIPTION
    * ridlbe/c++11/templates/cli/src/bitmask_cdr.erb:
    * ridlbe/c++11/templates/cli/src/bitset_cdr.erb:
    * ridlbe/c++11/templates/cli/src/enum_cdr.erb: