### PR TITLE
Cleanup constructor workarounds

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/interface_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/interface_post.erb
@@ -16,12 +16,7 @@ protected:
       TAOX11_CORBA::abstractbase_reference<TAOX11_CORBA::AbstractBase>);
 #endif /* clang <= 11 */
 
-%# msvc14.{0|1|2} have a problem with defaulted constructors, issue #4005
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-  <%= cxxname %> () {}
-#else
   <%= cxxname %> () = default;
-#endif /* _MSC_VER < 1930 */
   <%= cxxname %> (TAOX11_NAMESPACE::Abstractbase_proxy_ptr prx);
   ~<%= cxxname %> () override = default;
   /// Required for derived value types
@@ -72,15 +67,8 @@ private:
 protected:
   using _shared_ptr_type = std::shared_ptr<<%= cxxname %>>;
 
-%# msvc14.{0|1|2} have a bug that when using a defaulted constructor here we get a crash in the portableserver library
-%# for the POA
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-  /// Default constructor
-  <%= cxxname %> () {};
-#else
   /// Default constructor
   <%= cxxname %> () = default;
-#endif /* _MSC_VER < 1930 */
   /// Destructor
   ~<%= cxxname %> () override = default;
 

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -66,22 +66,12 @@ private:
   <%= switch_cxxtype %> disc_ {<% if has_default?() || has_implicit_default?() %><%= default_label %><% else %><%= members.first.nondefault_labels.first %><% end %>};
   union u_type_
   {
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-    u_type_ ();
-#else
     u_type_ () = default;
-#endif
     ~u_type_ ();
 % members.each do |_m|
 % # The default member or the first member should use the value_initializer
-% # Visual Studio 2019 doesn't seem to like using default, this leads to
-% # an internal compiler error, see SW331
 % if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-    <%= _m.cxx_member_type %> <%= _m.cxxname %>_;
-#else
     <%= _m.cxx_member_type %> <%= _m.cxxname %>_<% if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first) %> <%= _m.value_initializer %><% end %>;
-#endif
 % else
     <%= _m.cxx_member_type %> <%= _m.cxxname %>_;
 % end

--- a/ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb
+++ b/ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb
@@ -11,12 +11,7 @@ namespace obv
 % end
   {
   protected:
-%# msvc14.{0|1} have a problem with defaulted constructors, issue #4005
-#if defined (_MSC_VER) && (_MSC_VER < 1920)
-    <%= cxxname %> () {}
-#else
     <%= cxxname %> () = default;
-#endif /* _MSC_VER < 1920 */
     ~<%= cxxname %> () override = default;
     <%= cxxname %> (const <%= cxxname %>&) = default;
     <%= cxxname %> (<%= cxxname %>&&) = default;

--- a/ridlbe/c++11/templates/cli/inl/union_inl.erb
+++ b/ridlbe/c++11/templates/cli/inl/union_inl.erb
@@ -1,15 +1,4 @@
 // generated from <%= ridl_template_path %>
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-inline <%= scoped_cxxname %>::u_type_::u_type_ ()
-% if has_default?()
-  : <%= default_member.cxxname %>_<%= default_member.value_initializer %>
-% else
-  : <%= members.first.cxxname %>_<%= members.first.value_initializer %>
-% end
-{
-}
-#endif
-
 inline <%= scoped_cxxname %>::u_type_::~u_type_ ()
 {
 }


### PR DESCRIPTION
    * ridlbe/c++11/templates/cli/hdr/interface_post.erb:
    * ridlbe/c++11/templates/cli/hdr/union_post.erb:
    * ridlbe/c++11/templates/cli/hdr/valuetype_obv.erb:
    * ridlbe/c++11/templates/cli/inl/union_inl.erb: