### PR TITLE
Major rework to the union support

### DIFF
--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -63,14 +63,12 @@ private:
   inline void _move_u (<%= cxx_inout_type %> u);
   inline void _clear ();
 
-
+  <%= switch_cxxtype %> disc_ {<% if has_default?() || has_implicit_default?() %><%= default_label %><% else %><%= members.first.nondefault_labels.first %><% end %>};
   std::variant <
 % unique_member_types.each do |_m|
-  <%= _m %><% unless _m.equal?(enumerators.last)%>,<%end%>
+    <%= _m %><% unless _m == unique_member_types.last%>,<%end%>
 % end
-  > vv;
-
-  <%= switch_cxxtype %> disc_ {<% if has_default?() || has_implicit_default?() %><%= default_label %><% else %><%= members.first.nondefault_labels.first %><% end %>};
+    > u_type_;
   union u_type_
   {
     u_type_ () = default;

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -65,7 +65,9 @@ private:
 % members.each_with_index do |_m, _index|
 %   if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
 %     def_index = _index
-%     default_value = ", #{_m.default_value}"
+%     if _m.default_value != nil
+%       default_value = ", #{_m.default_value}"
+%     end
 %   end
 % end
 %# The default member or the first member should use the value_initializer

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -5,8 +5,7 @@
 % else
   /// Default constructor creating an empty union
 %end
-%# gcc < 13 has problems when the constructor is default
-  inline <%= cxxname %> ();
+  <%= cxxname %> () = default;
   /// Copy constructor
   <%= cxxname %> (<%= cxx_in_type %>) = default;
   /// Move constructor
@@ -61,8 +60,18 @@
 private:
   <%= switch_cxxtype %> disc_ {<% if has_default?() || has_implicit_default?() %><%= default_label %><% else %><%= members.first.nondefault_labels.first %><% end %>};
   using u_type_ = std::variant<<% members.each do |_m| %><%= _m.cxx_member_type %><% unless _m.equal?(members.last) %>, <% end %><% end %>>;
-%# gcc < 13 has problems when we initialize u_ here
-  u_type_ u_;
+% def_index = 0
+% default_value = ''
+% members.each_with_index do |_m, _index|
+%   if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
+%     def_index = _index
+%     if _m.default_value != nil
+%       default_value = ", #{_m.default_value}"
+%     end
+%   end
+% end
+%# The default member or the first member should use the default_value
+  u_type_ u_ {std::in_place_index<<%= def_index %>><%= default_value %>};
 }; // class <%= cxxname %>
 
 inline void swap (<%= scoped_cxx_out_type %> m1, <%= scoped_cxx_out_type %> m2) { m1.swap (m2); }

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -22,7 +22,7 @@
   /// a BAD_PARAM exception is thrown
   inline void _d (<%= switch_in_cxxtype %>);
   /// Get the discriminator
-  inline <%= switch_in_cxxtype %> _d () const  { return this->disc_; }
+  [[nodiscard]] inline <%= switch_in_cxxtype %> _d () const  { return this->disc_; }
 % members.each do |_m|
 %if _m.is_default?
 % default_disc = default_label
@@ -42,10 +42,10 @@
 %   end
   /// Get the value of the union, if the discriminator doesn't match a
   /// BAD_PARAM exception is thrown
-  inline <%= _m.cxx_in_type %> <%= _m.cxxname %> () const;
+  [[nodiscard]] inline <%= _m.cxx_in_type %> <%= _m.cxxname %> () const;
   /// Get the value of the union, if the discriminator doesn't match a
   /// BAD_PARAM exception is thrown
-  inline <%= _m.cxx_out_type %> <%= _m.cxxname %> ();
+  [[nodiscard]] inline <%= _m.cxx_out_type %> <%= _m.cxxname %> ();
   //@}
 % end
 % if has_implicit_default?

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -8,15 +8,15 @@
 %end
   <%= cxxname %> () = default;
   /// Copy constructor
-  inline <%= cxxname %> (<%= cxx_in_type %>);
+  <%= cxxname %> (<%= cxx_in_type %>) = default;
   /// Move constructor
-  inline <%= cxxname %> (<%= cxx_move_type %>);
+  <%= cxxname %> (<%= cxx_move_type %>) = default;
   /// Destructor
-  inline ~<%= cxxname %> ();
+  ~<%= cxxname %> () = default;
   /// Copy assignment operator
-  inline <%= cxxtype %> &operator= (<%= cxx_in_type %>);
+  <%= cxxtype %> &operator= (<%= cxx_in_type %>) = default;
   /// Move assignment operator
-  inline <%= cxxtype %> &operator= (<%= cxx_move_type %>);
+  <%= cxxtype %> &operator= (<%= cxx_move_type %>) = default;
 
   /// Set the discriminator. Only possible to set it to a
   /// value within the same current union member, otherwise
@@ -59,10 +59,6 @@
   inline void swap (<%= cxx_inout_type %> u);
 
 private:
-  inline void _swap_u (<%= cxx_inout_type %> u);
-  inline void _move_u (<%= cxx_inout_type %> u);
-  inline void _clear ();
-
   <%= switch_cxxtype %> disc_ {<% if has_default?() || has_implicit_default?() %><%= default_label %><% else %><%= members.first.nondefault_labels.first %><% end %>};
 % unique_member_types = []
 % members.each do |_m|

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -69,15 +69,18 @@ private:
 %#  {
 %#    u_type_ () = default;
 %#    ~u_type_ ();
-%# % members.each do |_m|
+% def_index = 0
+% members.each_with_index do |_m, _index|
 %# % # The default member or the first member should use the value_initializer
-%# % if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
+% if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
+%   def_index = _index
 %#    <%= _m.cxx_member_type %> <%= _m.cxxname %>_<% if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first) %> <%= _m.value_initializer %><% end %>;
 %#% else
 %#    <%= _m.cxx_member_type %> <%= _m.cxxname %>_;
-%#% end
-%#% end
-  u_type_ u_ {}; // todo set default
+% end
+% end
+% # The default member or the first member should use the value_initializer
+  u_type_ u_ {std::in_place_index<<%= def_index %>>};
 }; // class <%= cxxname %>
 
 inline void swap (<%= scoped_cxx_out_type %> m1, <%= scoped_cxx_out_type %> m2) { m1.swap (m2); }

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -1,4 +1,3 @@
-
   // generated from <%= ridl_template_path %>
 % if has_implicit_default? || has_default?
   /// Default constructor creating an union initialized to
@@ -84,4 +83,3 @@ private:
 }; // class <%= cxxname %>
 
 inline void swap (<%= scoped_cxx_out_type %> m1, <%= scoped_cxx_out_type %> m2) { m1.swap (m2); }
-

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -61,18 +61,8 @@
 private:
   <%= switch_cxxtype %> disc_ {<% if has_default?() || has_implicit_default?() %><%= default_label %><% else %><%= members.first.nondefault_labels.first %><% end %>};
   using u_type_ = std::variant<<% members.each do |_m| %><%= _m.cxx_member_type %><% unless _m.equal?(members.last) %>, <% end %><% end %>>;
-% def_index = 0
-% default_value = ''
-% members.each_with_index do |_m, _index|
-%   if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
-%     def_index = _index
-%     if _m.default_value != nil
-%       default_value = ", #{_m.default_value}"
-%     end
-%   end
-% end
-%# The default member or the first member should use the value_initializer
-  u_type_ u_ {std::in_place_index<<%= def_index %>><%= default_value %>};
+%# gcc < 13 has problems when we initialize u_ here
+  u_type_ u_;
 }; // class <%= cxxname %>
 
 inline void swap (<%= scoped_cxx_out_type %> m1, <%= scoped_cxx_out_type %> m2) { m1.swap (m2); }

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -64,11 +64,11 @@ private:
   inline void _clear ();
 
   <%= switch_cxxtype %> disc_ {<% if has_default?() || has_implicit_default?() %><%= default_label %><% else %><%= members.first.nondefault_labels.first %><% end %>};
-  std::variant <
-% unique_member_types.each do |_m|
-    <%= _m %><% unless _m == unique_member_types.last%>,<%end%>
+% unique_member_types = []
+% members.each do |_m|
+%   unique_member_types |= [_m.cxx_member_type]
 % end
-    > u_type_;
+  std::variant <<% unique_member_types.each do |_m| %><%= _m %><% unless _m == unique_member_types.last %>, <% end %><% end %>> u_type_;
   union u_type_
   {
     u_type_ () = default;

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -63,6 +63,13 @@ private:
   inline void _move_u (<%= cxx_inout_type %> u);
   inline void _clear ();
 
+
+  std::variant <
+% unique_member_types.each do |_m|
+  <%= _m %><% unless _m.equal?(enumerators.last)%>,<%end%>
+% end
+  > vv;
+
   <%= switch_cxxtype %> disc_ {<% if has_default?() || has_implicit_default?() %><%= default_label %><% else %><%= members.first.nondefault_labels.first %><% end %>};
   union u_type_
   {

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -59,27 +59,16 @@
 
 private:
   <%= switch_cxxtype %> disc_ {<% if has_default?() || has_implicit_default?() %><%= default_label %><% else %><%= members.first.nondefault_labels.first %><% end %>};
-% unique_member_types = []
-% members.each do |_m|
-%   unique_member_types << _m.cxx_member_type
-% end
   using u_type_ = std::variant<<% members.each do |_m| %><%= _m.cxx_member_type %><% unless _m.equal?(members.last) %>, <% end %><% end %>>;
-%#  union u_type_
-%#  {
-%#    u_type_ () = default;
-%#    ~u_type_ ();
 % def_index = 0
 % default_value = ''
 % members.each_with_index do |_m, _index|
-%# % # The default member or the first member should use the value_initializer
-% if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
-%   def_index = _index
-%   default_value = ", #{_m.default_value}"
-%#% else
-%#    <%= _m.cxx_member_type %> <%= _m.cxxname %>_;
+%   if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
+%     def_index = _index
+%     default_value = ", #{_m.default_value}"
+%   end
 % end
-% end
-% # The default member or the first member should use the value_initializer
+%# The default member or the first member should use the value_initializer
   u_type_ u_ {std::in_place_index<<%= def_index %>><%= default_value %>};
 }; // class <%= cxxname %>
 

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -5,7 +5,8 @@
 % else
   /// Default constructor creating an empty union
 %end
-  <%= cxxname %> () = default;
+%# gcc < 13 has problems when the constructor is default
+  inline <%= cxxname %> ();
   /// Copy constructor
   <%= cxxname %> (<%= cxx_in_type %>) = default;
   /// Move constructor
@@ -22,7 +23,7 @@
   /// a BAD_PARAM exception is thrown
   inline void _d (<%= switch_in_cxxtype %>);
   /// Get the discriminator
-  [[nodiscard]] inline <%= switch_in_cxxtype %> _d () const  { return this->disc_; }
+  inline <%= switch_in_cxxtype %> _d () const  { return this->disc_; }
 % members.each do |_m|
 %if _m.is_default?
 % default_disc = default_label
@@ -42,10 +43,10 @@
 %   end
   /// Get the value of the union, if the discriminator doesn't match a
   /// BAD_PARAM exception is thrown
-  [[nodiscard]] inline <%= _m.cxx_in_type %> <%= _m.cxxname %> () const;
+  inline <%= _m.cxx_in_type %> <%= _m.cxxname %> () const;
   /// Get the value of the union, if the discriminator doesn't match a
   /// BAD_PARAM exception is thrown
-  [[nodiscard]] inline <%= _m.cxx_out_type %> <%= _m.cxxname %> ();
+  inline <%= _m.cxx_out_type %> <%= _m.cxxname %> ();
   //@}
 % end
 % if has_implicit_default?

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -69,17 +69,18 @@ private:
 %#    u_type_ () = default;
 %#    ~u_type_ ();
 % def_index = 0
+% default_value = ''
 % members.each_with_index do |_m, _index|
 %# % # The default member or the first member should use the value_initializer
 % if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
 %   def_index = _index
-%#    <%= _m.cxx_member_type %> <%= _m.cxxname %>_<% if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first) %> <%= _m.value_initializer %><% end %>;
+%   default_value = ", #{_m.default_value}"
 %#% else
 %#    <%= _m.cxx_member_type %> <%= _m.cxxname %>_;
 % end
 % end
 % # The default member or the first member should use the value_initializer
-  u_type_ u_ {std::in_place_index<<%= def_index %>>};
+  u_type_ u_ {std::in_place_index<<%= def_index %>><%= default_value %>};
 }; // class <%= cxxname %>
 
 inline void swap (<%= scoped_cxx_out_type %> m1, <%= scoped_cxx_out_type %> m2) { m1.swap (m2); }

--- a/ridlbe/c++11/templates/cli/hdr/union_post.erb
+++ b/ridlbe/c++11/templates/cli/hdr/union_post.erb
@@ -66,22 +66,22 @@ private:
   <%= switch_cxxtype %> disc_ {<% if has_default?() || has_implicit_default?() %><%= default_label %><% else %><%= members.first.nondefault_labels.first %><% end %>};
 % unique_member_types = []
 % members.each do |_m|
-%   unique_member_types |= [_m.cxx_member_type]
+%   unique_member_types << _m.cxx_member_type
 % end
-  std::variant <<% unique_member_types.each do |_m| %><%= _m %><% unless _m == unique_member_types.last %>, <% end %><% end %>> u_type_;
-  union u_type_
-  {
-    u_type_ () = default;
-    ~u_type_ ();
-% members.each do |_m|
-% # The default member or the first member should use the value_initializer
-% if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
-    <%= _m.cxx_member_type %> <%= _m.cxxname %>_<% if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first) %> <%= _m.value_initializer %><% end %>;
-% else
-    <%= _m.cxx_member_type %> <%= _m.cxxname %>_;
-% end
-% end
-  } u_ {};
+  using u_type_ = std::variant<<% members.each do |_m| %><%= _m.cxx_member_type %><% unless _m.equal?(members.last) %>, <% end %><% end %>>;
+%#  union u_type_
+%#  {
+%#    u_type_ () = default;
+%#    ~u_type_ ();
+%# % members.each do |_m|
+%# % # The default member or the first member should use the value_initializer
+%# % if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
+%#    <%= _m.cxx_member_type %> <%= _m.cxxname %>_<% if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first) %> <%= _m.value_initializer %><% end %>;
+%#% else
+%#    <%= _m.cxx_member_type %> <%= _m.cxxname %>_;
+%#% end
+%#% end
+  u_type_ u_ {}; // todo set default
 }; // class <%= cxxname %>
 
 inline void swap (<%= scoped_cxx_out_type %> m1, <%= scoped_cxx_out_type %> m2) { m1.swap (m2); }

--- a/ridlbe/c++11/templates/cli/inl/union_inl.erb
+++ b/ridlbe/c++11/templates/cli/inl/union_inl.erb
@@ -56,7 +56,7 @@ inline void <%= scoped_cxxname %>::_d (<%= switch_in_cxxtype %> discval)
 % end
   }
 }
-% members.each do |_m|
+% members.each_with_index do |_m, _index|
 %if _m.is_default?
 % default_disc = default_label
 %else
@@ -111,15 +111,15 @@ inline void <%= scoped_cxxname %>::<%= _m.cxxname %> (<%= _m.cxx_in_type %> _x11
     this->disc_ = <% if _m.has_multiple_discriminators? %>_x11_disc<% else %><%= _m.nondefault_labels.first %><% end %>;
 %   end
 %   unless _m.is_pod?
-    this->u_ = _x11_<%= _m.cxxname %>;
+    this->u_.emplace<<%= _index %>>(_x11_<%= _m.cxxname %>);
   }
   else
   {
-    this->u_ = _x11_<%= _m.cxxname %>;
+    this->u_.emplace<<%= _index %>>(_x11_<%= _m.cxxname %>);
   }
 %   else
   }
-  this->u_ = _x11_<%= _m.cxxname %>;
+  this->u_.emplace<<%= _index %>>(_x11_<%= _m.cxxname %>);
 %   end
 }
 %   unless _m.is_pod? || _m.is_reference?
@@ -216,7 +216,7 @@ inline <%= _m.scoped_cxx_in_type %> <%= scoped_cxxname %>::<%= _m.cxxname %> () 
 %     end
   }
 %   end
-  return std::get<<%= _m.scoped_cxx_in_type %>>(this->u_);
+  return std::get<<%= _index %>>(this->u_);
 }
 
 inline <%= _m.scoped_cxx_out_type %> <%= scoped_cxxname %>::<%= _m.cxxname %> ()
@@ -251,7 +251,7 @@ inline <%= _m.scoped_cxx_out_type %> <%= scoped_cxxname %>::<%= _m.cxxname %> ()
 %     end
   }
 %   end
-  return std::get<<%= _m.scoped_cxx_out_type %>>(this->u_);
+  return std::get<<%= _index %>>(this->u_);
 }
 % end
 
@@ -269,7 +269,7 @@ inline void <%= scoped_cxxname %>::_default ()
 {
   this->disc_ = <%= default_label %>;
 %   if !members.first.is_pod?
-  new (std::addressof(this->u_.<%= members.first.cxxname %>_)) <%= members.first.cxx_member_type %> ();
+  this->u_.emplace<0>(<%= members.first.cxx_member_type %>{});
 %   end
 }
 % end

--- a/ridlbe/c++11/templates/cli/inl/union_inl.erb
+++ b/ridlbe/c++11/templates/cli/inl/union_inl.erb
@@ -99,28 +99,12 @@ inline void <%= scoped_cxxname %>::<%= _m.cxxname %> (<%= _m.cxx_in_type %> _x11
 %   end
 % end
 %   _lbl = _m.has_multiple_discriminators? ? '_x11_disc' : _m.is_default? ? default_label : _m.nondefault_labels.first
-%   if switchtype_boolean?
-  if (<%= _lbl == 'true' ? '!' : '' %>this->disc_)
-%   else
-  if (this->disc_ != <%= _lbl %>)
-%   end
-  {
 %   if _m.is_default?
-    this->disc_ = _x11_disc;
+  this->disc_ = _x11_disc;
 %   else
-    this->disc_ = <% if _m.has_multiple_discriminators? %>_x11_disc<% else %><%= _m.nondefault_labels.first %><% end %>;
+  this->disc_ = <% if _m.has_multiple_discriminators? %>_x11_disc<% else %><%= _m.nondefault_labels.first %><% end %>;
 %   end
-%   unless _m.is_pod?
-    this->u_.emplace<<%= _index %>>(_x11_<%= _m.cxxname %>);
-  }
-  else
-  {
-    this->u_.emplace<<%= _index %>>(_x11_<%= _m.cxxname %>);
-  }
-%   else
-  }
   this->u_.emplace<<%= _index %>>(_x11_<%= _m.cxxname %>);
-%   end
 }
 %   unless _m.is_pod? || _m.is_reference?
 
@@ -159,28 +143,12 @@ inline void <%= scoped_cxxname %>::<%= _m.cxxname %> (<%= _m.cxx_move_type %> _x
   }
 %   end
 % end
-%   if switchtype_boolean?
-  if (<%= _lbl == 'true' ? '!' : '' %>this->disc_)
-%   else
-  if (this->disc_ != <%= _lbl %>)
-%   end
-  {
 %     if _m.is_default?
-    this->disc_ = _x11_disc;
+  this->disc_ = _x11_disc;
 %     else
-    this->disc_ = <% if _m.has_multiple_discriminators? %>_x11_disc<% else %><%= _m.nondefault_labels.first %><% end %>;
+  this->disc_ = <% if _m.has_multiple_discriminators? %>_x11_disc<% else %><%= _m.nondefault_labels.first %><% end %>;
 %     end
-%     unless _m.is_pod?
-    this->u_ = std::move(_x11_<%= _m.cxxname %>);
-  }
-  else
-  {
-    this->u_ = std::move (_x11_<%= _m.cxxname %>);
-  }
-%     else
-  }
-  this->u_ = std::move (_x11_<%= _m.cxxname %>);
-%     end
+  this->u_.emplace<<%= _index %>>(std::move (_x11_<%= _m.cxxname %>));
 }
 %   end
 

--- a/ridlbe/c++11/templates/cli/inl/union_inl.erb
+++ b/ridlbe/c++11/templates/cli/inl/union_inl.erb
@@ -1,5 +1,16 @@
 // generated from <%= ridl_template_path %>
-inline <%= scoped_cxxname %>::<%= cxxname %> ()
+% def_index = 0
+% default_value = ''
+% members.each_with_index do |_m, _index|
+%   if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
+%     def_index = _index
+%     if _m.default_value != nil
+%       default_value = ", #{_m.default_value}"
+%     end
+%   end
+% end
+%# The default member or the first member should use the default_value
+inline <%= scoped_cxxname %>::<%= cxxname %> () : u_ {std::in_place_index<<%= def_index %>><%= default_value %>}
 {
 }
 

--- a/ridlbe/c++11/templates/cli/inl/union_inl.erb
+++ b/ridlbe/c++11/templates/cli/inl/union_inl.erb
@@ -1,19 +1,4 @@
 // generated from <%= ridl_template_path %>
-% def_index = 0
-% default_value = ''
-% members.each_with_index do |_m, _index|
-%   if (has_default?() && _m.is_default?) || (!has_default?() && _m == members.first)
-%     def_index = _index
-%     if _m.default_value != nil
-%       default_value = ", #{_m.default_value}"
-%     end
-%   end
-% end
-%# The default member or the first member should use the default_value
-inline <%= scoped_cxxname %>::<%= cxxname %> () : u_ {std::in_place_index<<%= def_index %>><%= default_value %>}
-{
-}
-
 inline void <%= scoped_cxxname %>::_d (<%= switch_in_cxxtype %> discval)
 {
   if (this->disc_ != discval)

--- a/ridlbe/c++11/templates/cli/inl/union_inl.erb
+++ b/ridlbe/c++11/templates/cli/inl/union_inl.erb
@@ -1,93 +1,4 @@
 // generated from <%= ridl_template_path %>
-inline <%= scoped_cxxname %>::u_type_::~u_type_ ()
-{
-}
-
-inline <%= scoped_cxxname %>::~<%= cxxname %> ()
-{
-  this->_clear ();
-}
-
-inline <%= scoped_cxxname %>::<%= cxxname %> (<%= scoped_cxx_in_type %> u)
-  : disc_ (u.disc_)
-{
-% if switchtype_boolean?
-%   _defmem = default_member
-%   _ndefmem = non_default_members
-%   if (_defmem && _ndefmem.empty?) || (!_ndefmem.empty? && _ndefmem.first.labels.size>1)
-%     # in these cases there is only a single member mapping all labels
-%     _m = _defmem || _ndefmem.shift
-%     if _m.is_pod?
-  this->u_.<%= _m.cxxname %>_ = u.u_.<%= _m.cxxname %>_;
-%     else
-  new (std::addressof(this->u_.<%= _m.cxxname %>_)) <%= _m.cxx_member_type %> (u.u_.<%= _m.cxxname %>_);
-%     end
-%   else
-%     # here we have 1 or 2 nondef members with or without a default
-%     _m = _ndefmem.shift # get first non-default member
-%     _lbl = _m.labels.first
-  if (<%= _lbl == 'false' ? '!' : '' %>this->disc_)
-  {
-%     if _m.is_pod?
-    this->u_.<%= _m.cxxname %>_ = u.u_.<%= _m.cxxname %>_;
-%     else
-    new (std::addressof(this->u_.<%= _m.cxxname %>_)) <%= _m.cxx_member_type %> (u.u_.<%= _m.cxxname %>_);
-%     end
-  }
-%     if _defmem || !_ndefmem.empty?
-  else
-  {
-%     _m = _defmem || _ndefmem.shift # get other (non-)default member
-%     if _m.is_pod?
-    this->u_.<%= _m.cxxname %>_ = u.u_.<%= _m.cxxname %>_;
-%     else
-    new (std::addressof(this->u_.<%= _m.cxxname %>_)) <%= _m.cxx_member_type %> (u.u_.<%= _m.cxxname %>_);
-%     end
-  }
-%     end
-%   end
-% else
-  switch (this->disc_)
-  {
-% members.each do |_m|
-%   unless _m.is_default?
-%     _m.nondefault_labels.each do |_lbl|
-    case <%= _lbl %>:
-%     end
-    {
-%     if _m.is_pod?
-      this->u_.<%= _m.cxxname %>_ = u.u_.<%= _m.cxxname %>_;
-%     else
-      new (std::addressof(this->u_.<%= _m.cxxname %>_)) <%= _m.cxx_member_type %> (u.u_.<%= _m.cxxname %>_);
-%     end
-    }
-    break;
-%   end
-% end
-% if needs_switch_default?
-    default:
-%   if has_default?
-%     _m_def = default_member
-    {
-%     if _m_def.is_pod?
-      this->u_.<%= _m_def.cxxname %>_ = u.u_.<%= _m_def.cxxname %>_;
-%     else
-      new (std::addressof(this->u_.<%= _m_def.cxxname %>_)) <%= _m_def.cxx_member_type %> (u.u_.<%= _m_def.cxxname %>_);
-%     end
-    }
-%   end
-    break;
-% end
-  }
-% end
-}
-
-inline <%= scoped_cxxname %>::<%= cxxname %> (<%= scoped_cxx_move_type %> u)
-  : disc_ (std::move (u.disc_))
-{
-  this->_move_u (u);
-}
-
 inline void <%= scoped_cxxname %>::_d (<%= switch_in_cxxtype %> discval)
 {
   if (this->disc_ != discval)
@@ -194,22 +105,21 @@ inline void <%= scoped_cxxname %>::<%= _m.cxxname %> (<%= _m.cxx_in_type %> _x11
   if (this->disc_ != <%= _lbl %>)
 %   end
   {
-    this->_clear ();
 %   if _m.is_default?
     this->disc_ = _x11_disc;
 %   else
     this->disc_ = <% if _m.has_multiple_discriminators? %>_x11_disc<% else %><%= _m.nondefault_labels.first %><% end %>;
 %   end
 %   unless _m.is_pod?
-    new (std::addressof(this->u_.<%= _m.cxxname %>_)) <%= _m.cxx_member_type %> (_x11_<%= _m.cxxname %>);
+    this->u_ = _x11_<%= _m.cxxname %>;
   }
   else
   {
-    this->u_.<%= _m.cxxname %>_ = _x11_<%= _m.cxxname %>;
+    this->u_ = _x11_<%= _m.cxxname %>;
   }
 %   else
   }
-  this->u_.<%= _m.cxxname %>_ = _x11_<%= _m.cxxname %>;
+  this->u_ = _x11_<%= _m.cxxname %>;
 %   end
 }
 %   unless _m.is_pod? || _m.is_reference?
@@ -255,22 +165,21 @@ inline void <%= scoped_cxxname %>::<%= _m.cxxname %> (<%= _m.cxx_move_type %> _x
   if (this->disc_ != <%= _lbl %>)
 %   end
   {
-    this->_clear ();
 %     if _m.is_default?
     this->disc_ = _x11_disc;
 %     else
     this->disc_ = <% if _m.has_multiple_discriminators? %>_x11_disc<% else %><%= _m.nondefault_labels.first %><% end %>;
 %     end
 %     unless _m.is_pod?
-    new (std::addressof(this->u_.<%= _m.cxxname %>_)) <%= _m.cxx_member_type %> (std::move (_x11_<%= _m.cxxname %>));
+    this->u_ = std::move(_x11_<%= _m.cxxname %>);
   }
   else
   {
-    this->u_.<%= _m.cxxname %>_ = std::move (_x11_<%= _m.cxxname %>);
+    this->u_ = std::move (_x11_<%= _m.cxxname %>);
   }
 %     else
   }
-  this->u_.<%= _m.cxxname %>_ = std::move (_x11_<%= _m.cxxname %>);
+  this->u_ = std::move (_x11_<%= _m.cxxname %>);
 %     end
 }
 %   end
@@ -307,7 +216,7 @@ inline <%= _m.scoped_cxx_in_type %> <%= scoped_cxxname %>::<%= _m.cxxname %> () 
 %     end
   }
 %   end
-  return this->u_.<%= _m.cxxname %>_;
+  return std::get<<%= _m.scoped_cxx_in_type %>>(this->u_);
 }
 
 inline <%= _m.scoped_cxx_out_type %> <%= scoped_cxxname %>::<%= _m.cxxname %> ()
@@ -342,249 +251,22 @@ inline <%= _m.scoped_cxx_out_type %> <%= scoped_cxxname %>::<%= _m.cxxname %> ()
 %     end
   }
 %   end
-  return this->u_.<%= _m.cxxname %>_;
+  return std::get<<%= _m.scoped_cxx_out_type %>>(this->u_);
 }
 % end
-
-inline <%= scoped_cxx_out_type %> <%= scoped_cxxname %>::operator= (<%= scoped_cxx_in_type %> u)
-{
-  if (this != std::addressof(u))
-  {
-    <%= cxxtype %> tmp (u);
-    this->swap (tmp);
-  }
-  return *this;
-}
-
-inline <%= scoped_cxx_out_type %> <%= scoped_cxxname %>::operator= (<%= scoped_cxx_move_type %> u)
-{
-  if (this != std::addressof(u))
-  {
-    <%= cxxtype %> tmp (std::move (u));
-    this->swap (tmp);
-  }
-  return *this;
-}
 
 inline void <%= scoped_cxxname %>::swap (<%= scoped_cxx_out_type %> u)
 {
   if (this != std::addressof(u))
   {
-    if (this->disc_ != u.disc_)
-    {
-      // different datatypes; so use move semantics to swap efficiently through intermediary
-      <%= scoped_cxxtype %> intermediate (std::move (*this));
-      this->disc_ = std::move (u.disc_);
-      this->_move_u (u);
-      u.disc_ = std::move (intermediate.disc_);
-      u._move_u (intermediate);
-    }
-    else
-    {
-      // same datatypes so swap directly
-      this->_swap_u (u);
-    }
+    std::swap (this->disc_, u.disc_);
+    std::swap (this->u_, u.u_);
   }
-}
-
-inline void <%= scoped_cxxname %>::_swap_u (<%= scoped_cxx_out_type %> u)
-{
-  // u_ members have been guaranteed initialized identically so simply swap data
-% if switchtype_boolean?
-%   _defmem = default_member
-%   _ndefmem = non_default_members
-%   if (_defmem && _ndefmem.empty?) || (!_ndefmem.empty? && _ndefmem.first.labels.size>1)
-%     # in these cases there is only a single member mapping all labels
-%     _m = _defmem || _ndefmem.shift
-  std::swap (this->u_.<%= _m.cxxname %>_, u.u_.<%= _m.cxxname %>_);
-%   else
-%     # here we have 1 or 2 nondef members with or without a default
-%     _m = _ndefmem.shift # get first non-default member
-%     _lbl = _m.labels.first
-  if (<%= _lbl == 'false' ? '!' : '' %>this->disc_)
-  {
-    std::swap (this->u_.<%= _m.cxxname %>_, u.u_.<%= _m.cxxname %>_);
-  }
-%     if _defmem || !_ndefmem.empty?
-  else
-  {
-%     _m = _defmem || _ndefmem.shift # get other (non-)default member
-    std::swap (this->u_.<%= _m.cxxname %>_, u.u_.<%= _m.cxxname %>_);
-  }
-%     end
-%   end
-% else
-  switch (this->disc_)
-  {
-%   members.each do |_m|
-%     unless _m.is_default?
-%       _m.nondefault_labels.each do |_lbl|
-    case <%= _lbl %>:
-%       end
-    {
-      std::swap (this->u_.<%= _m.cxxname %>_, u.u_.<%= _m.cxxname %>_);
-    }
-    break;
-%     end
-%   end
-%   if needs_switch_default?
-    default:
-%     _m_def = has_default? ? default_member : members.first
-    {
-      std::swap (this->u_.<%= _m_def.cxxname %>_, u.u_.<%= _m_def.cxxname %>_);
-    }
-    break;
-%   end
-  }
-% end
-}
-
-inline void <%= scoped_cxxname %>::_move_u (<%= scoped_cxx_inout_type %> u)
-{
-  // this->disc_ is guaranteed to be initialized with the value from u.disc_ so it's safe
-  // to move/initialize the corresponding union members
-% if switchtype_boolean?
-%   _defmem = default_member
-%   _ndefmem = non_default_members
-%   if (_defmem && _ndefmem.empty?) || (!_ndefmem.empty? && _ndefmem.first.labels.size>1)
-%     # in these cases there is only a single member mapping all labels
-%     _m = _defmem || _ndefmem.shift
-%     if _m.is_pod?
-  this->u_.<%= _m.cxxname %>_ = std::move (u.u_.<%= _m.cxxname %>_);
-%     else
-  new (std::addressof(this->u_.<%= _m.cxxname %>_)) <%= _m.cxx_member_type %> (std::move (u.u_.<%= _m.cxxname %>_));
-%     end
-%   else
-%     # here we have 1 or 2 nondef members with or without a default
-%     _m = _ndefmem.shift # get first non-default member
-%     _lbl = _m.labels.first
-  if (<%= _lbl == 'false' ? '!' : '' %>this->disc_)
-  {
-%     if _m.is_pod?
-    this->u_.<%= _m.cxxname %>_ = std::move (u.u_.<%= _m.cxxname %>_);
-%     else
-    new (std::addressof(this->u_.<%= _m.cxxname %>_)) <%= _m.cxx_member_type %> (std::move (u.u_.<%= _m.cxxname %>_));
-%     end
-  }
-%     if _defmem || !_ndefmem.empty?
-  else
-  {
-%     _m = _defmem || _ndefmem.shift # get other (non-)default member
-%     if _m.is_pod?
-    this->u_.<%= _m.cxxname %>_ = std::move (u.u_.<%= _m.cxxname %>_);
-%     else
-    new (std::addressof(this->u_.<%= _m.cxxname %>_)) <%= _m.cxx_member_type %> (std::move (u.u_.<%= _m.cxxname %>_));
-%     end
-  }
-%     end
-%   end
-% else
-  switch (this->disc_)
-  {
-%   members.each do |_m|
-%     unless _m.is_default?
-%       _m.nondefault_labels.each do |_lbl|
-    case <%= _lbl %>:
-%       end
-    {
-%       if _m.is_pod?
-      this->u_.<%= _m.cxxname %>_ = std::move (u.u_.<%= _m.cxxname %>_);
-%       else
-      new (std::addressof(this->u_.<%= _m.cxxname %>_)) <%= _m.cxx_member_type %> (std::move (u.u_.<%= _m.cxxname %>_));
-%       end
-    }
-    break;
-%     end
-%   end
-%   if needs_switch_default?
-    default:
-%     _m_def = has_default? ? default_member : members.first
-    {
-%     if _m_def.is_pod?
-      this->u_.<%= _m_def.cxxname %>_ = std::move (u.u_.<%= _m_def.cxxname %>_);
-%     else
-      new (std::addressof(this->u_.<%= _m_def.cxxname %>_)) <%= _m_def.cxx_member_type %> (std::move (u.u_.<%= _m_def.cxxname %>_));
-%     end
-    }
-    break;
-%   end
-  }
-% end
-}
-
-inline void <%= scoped_cxxname %>::_clear ()
-{
-% if switchtype_boolean?
-%   _defmem = default_member
-%   _ndefmem = non_default_members
-%   if (_defmem && _ndefmem.empty?) || (!_ndefmem.empty? && _ndefmem.first.labels.size>1)
-%     # in these cases there is only a single member mapping all labels
-%     _m = _defmem || _ndefmem.shift
-%     unless _m.is_pod?
-%       unless _m.is_reference?
-%       end
-  this->u_.<%= _m.cxxname %>_.<%= _m.cxx_member_type %>::~<%= _m.cxx_member_type_name %> ();
-%     end
-%   else
-%     # here we have 1 or 2 nondef members with or without a default
-%     _m = _ndefmem.shift # get first non-default member
-%     _lbl = _m.labels.first
-%     unless _m.is_pod?
-  if (<%= _lbl == 'false' ? '!' : '' %>this->disc_)
-  {
-    this->u_.<%= _m.cxxname %>_.<%= _m.cxx_member_type %>::~<%= _m.cxx_member_type_name %> ();
-  }
-%     end
-%     if _defmem || !_ndefmem.empty?
-%       _m2 = _defmem || _ndefmem.shift # get other (non-)default member
-%       unless _m2.is_pod?
-%         if _m.is_pod?
-%           _lbl = _m2.labels.first
-  if (<%= _lbl == 'false' ? '!' : '' %>this->disc_)
-%         else
-  else
-%         end
-%           _m = _m2
-  {
-    this->u_.<%= _m.cxxname %>_.<%= _m.cxx_member_type %>::~<%= _m.cxx_member_type_name %> ();
-  }
-%       end
-%     end
-%   end
-% else
-  switch (this->disc_)
-  {
-%   members.each do |_m|
-%     unless _m.is_default?
-%       _m.nondefault_labels.each do |_lbl|
-    case <%= _lbl %>:
-%       end
-%       unless _m.is_pod?
-    {
-      this->u_.<%= _m.cxxname %>_.<%= _m.cxx_member_type %>::~<%= _m.cxx_member_type_name %> ();
-    }
-%       end
-    break;
-%     end
-%   end
-%   if needs_switch_default?
-    default:
-%     _m_def = has_default? ? default_member : members.first
-%     unless _m_def.is_pod?
-    {
-      this->u_.<%= _m_def.cxxname %>_.<%= _m_def.cxx_member_type %>::~<%= _m_def.cxx_member_type_name %> ();
-    }
-%     end
-    break;
-%   end
-  }
-% end
 }
 % if has_implicit_default?
 
 inline void <%= scoped_cxxname %>::_default ()
 {
-  this->_clear ();
   this->disc_ = <%= default_label %>;
 %   if !members.first.is_pod?
   new (std::addressof(this->u_.<%= members.first.cxxname %>_)) <%= members.first.cxx_member_type %> ();

--- a/ridlbe/c++11/templates/cli/inl/union_inl.erb
+++ b/ridlbe/c++11/templates/cli/inl/union_inl.erb
@@ -102,7 +102,6 @@ inline void <%= scoped_cxxname %>::<%= _m.cxxname %> (<%= _m.cxx_in_type %> _x11
   }
 %   end
 % end
-%   _lbl = _m.has_multiple_discriminators? ? '_x11_disc' : _m.is_default? ? default_label : _m.nondefault_labels.first
 %   if _m.is_default?
   this->disc_ = _x11_disc;
 %   else

--- a/ridlbe/c++11/templates/cli/inl/union_inl.erb
+++ b/ridlbe/c++11/templates/cli/inl/union_inl.erb
@@ -225,11 +225,8 @@ inline <%= _m.scoped_cxx_out_type %> <%= scoped_cxxname %>::<%= _m.cxxname %> ()
 
 inline void <%= scoped_cxxname %>::swap (<%= scoped_cxx_out_type %> u)
 {
-  if (this != std::addressof(u))
-  {
-    std::swap (this->disc_, u.disc_);
-    std::swap (this->u_, u.u_);
-  }
+  std::swap (this->disc_, u.disc_);
+  std::swap (this->u_, u.u_);
 }
 % if has_implicit_default?
 

--- a/ridlbe/c++11/templates/cli/inl/union_inl.erb
+++ b/ridlbe/c++11/templates/cli/inl/union_inl.erb
@@ -1,4 +1,8 @@
 // generated from <%= ridl_template_path %>
+inline <%= scoped_cxxname %>::<%= cxxname %> ()
+{
+}
+
 inline void <%= scoped_cxxname %>::_d (<%= switch_in_cxxtype %> discval)
 {
   if (this->disc_ != discval)
@@ -233,8 +237,6 @@ inline void <%= scoped_cxxname %>::swap (<%= scoped_cxx_out_type %> u)
 inline void <%= scoped_cxxname %>::_default ()
 {
   this->disc_ = <%= default_label %>;
-%   if !members.first.is_pod?
   this->u_.emplace<0>(<%= members.first.cxx_member_type %>{});
-%   end
 }
 % end

--- a/ridlbe/c++11/templates/cli/inl/union_inl.erb
+++ b/ridlbe/c++11/templates/cli/inl/union_inl.erb
@@ -61,11 +61,6 @@ inline void <%= scoped_cxxname %>::_d (<%= switch_in_cxxtype %> discval)
   }
 }
 % members.each_with_index do |_m, _index|
-%if _m.is_default?
-% default_disc = default_label
-%else
-% default_disc = _m.nondefault_labels.first
-%end
 
 inline void <%= scoped_cxxname %>::<%= _m.cxxname %> (<%= _m.cxx_in_type %> _x11_<%= _m.cxxname %><% if _m.has_multiple_discriminators? %>, <%= switch_in_cxxtype %> _x11_disc<% end %>)
 {

--- a/ridlbe/c++11/visitors/union.rb
+++ b/ridlbe/c++11/visitors/union.rb
@@ -6,7 +6,6 @@
 #
 # @copyright Copyright (c) Remedy IT Expertise BV
 #--------------------------------------------------------------------
-require 'set'
 
 module IDL
   module Cxx11
@@ -19,12 +18,12 @@ module IDL
       end
 
       def unique_member_types
-        types = Set[]
+        types = []
         node.members.each do |_m|
           (umv = visitor(UnionMemberVisitor)).visit(_m)
-          types.add (umv.cxx_member_type)
+          types << (umv.cxx_member_type)
         end
-        types
+        types.uniq
       end
 
       def member_count

--- a/ridlbe/c++11/visitors/union.rb
+++ b/ridlbe/c++11/visitors/union.rb
@@ -6,6 +6,7 @@
 #
 # @copyright Copyright (c) Remedy IT Expertise BV
 #--------------------------------------------------------------------
+require 'set'
 
 module IDL
   module Cxx11
@@ -15,6 +16,15 @@ module IDL
           (umv = visitor(UnionMemberVisitor)).visit(um)
           umv
         end
+      end
+
+      def unique_member_types
+        types = Set[]
+        node.members.each do |_m|
+          (umv = visitor(UnionMemberVisitor)).visit(_m)
+          types.add (umv.cxx_member_type)
+        end
+        types
       end
 
       def member_count

--- a/ridlbe/c++11/visitors/union.rb
+++ b/ridlbe/c++11/visitors/union.rb
@@ -17,15 +17,6 @@ module IDL
         end
       end
 
-      def unique_member_types
-        types = []
-        node.members.each do |_m|
-          (umv = visitor(UnionMemberVisitor)).visit(_m)
-          types << (umv.cxx_member_type)
-        end
-        types.uniq
-      end
-
       def member_count
         node.members.size
       end

--- a/ridlbe/c++11/visitors/union.rb
+++ b/ridlbe/c++11/visitors/union.rb
@@ -191,6 +191,23 @@ module IDL
         end
       end
 
+      def default_value
+        # When we have an annotation directly applied to this node we are using it
+        unless node.annotations[:default].first.nil?
+          "#{node.annotations[:default].first.fields[:value]}"
+        else
+          # Check whether it is a typedef, if so, we need to see if there is an annotation applied to the typedef (or its typedef)
+          res_idl_type = _idltype
+          while res_idl_type.is_a?(IDL::Type::ScopedName)
+            unless res_idl_type.node.annotations[:default].first.nil?
+              return "#{res_idl_type.node.annotations[:default].first.fields[:value]}"
+            end
+            res_idl_type = res_idl_type.node.idltype
+          end
+          _resolved_idltype.default_value
+        end
+      end
+
       def cxx_byval_type
         if optional?
           "IDL::optional<#{cxx_return_type}>"

--- a/ridlbe/c++11/visitors/union.rb
+++ b/ridlbe/c++11/visitors/union.rb
@@ -174,33 +174,16 @@ module IDL
         labels.size > 1 || is_default?
       end
 
-      def value_initializer
-        # When we have an annotation directly applied to this node we are using it
-        unless node.annotations[:default].first.nil?
-          "{#{node.annotations[:default].first.fields[:value]}}"
-        else
-          # Check whether it is a typedef, if so, we need to see if there is an annotation applied to the typedef (or its typedef)
-          res_idl_type = _idltype
-          while res_idl_type.is_a?(IDL::Type::ScopedName)
-            unless res_idl_type.node.annotations[:default].first.nil?
-              return "{#{res_idl_type.node.annotations[:default].first.fields[:value]}}"
-            end
-            res_idl_type = res_idl_type.node.idltype
-          end
-          _resolved_idltype.value_initializer
-        end
-      end
-
       def default_value
         # When we have an annotation directly applied to this node we are using it
         unless node.annotations[:default].first.nil?
-          "#{node.annotations[:default].first.fields[:value]}"
+          node.annotations[:default].first.fields[:value].to_s
         else
           # Check whether it is a typedef, if so, we need to see if there is an annotation applied to the typedef (or its typedef)
           res_idl_type = _idltype
           while res_idl_type.is_a?(IDL::Type::ScopedName)
             unless res_idl_type.node.annotations[:default].first.nil?
-              return "#{res_idl_type.node.annotations[:default].first.fields[:value]}"
+              return res_idl_type.node.annotations[:default].first.fields[:value].to_s
             end
             res_idl_type = res_idl_type.node.idltype
           end

--- a/ridlbe/c++11/writers/stubheader.rb
+++ b/ridlbe/c++11/writers/stubheader.rb
@@ -437,6 +437,7 @@ module IDL
       def enter_union(node)
         add_include('tao/x11/system_exception.h') unless params[:gen_stub_proxy_source]
         add_pre_include('stdexcept') if params[:gen_stub_proxy_source]
+        add_pre_include('variant')
         node.members.each { |m| check_idl_type(m.idltype) }
       end
 

--- a/tests/union/checks.h
+++ b/tests/union/checks.h
@@ -23,10 +23,10 @@ check_bad_param (
       case Test::DataType::dtEmpty: break;
       case Test::DataType::dtLong: d.longData (); break;
       case Test::DataType::dtShort: d.shortData (); break;
-      case Test::DataType::dtString:d.stringData (); break;
+      case Test::DataType::dtString: d.stringData (); break;
       case Test::DataType::dtPoint: d.pointData (); break;
       case Test::DataType::dtTrack: d.trackData (); break;
-      case Test::DataType::dtGlobal:d.globalData (); break;
+      case Test::DataType::dtGlobal: d.globalData (); break;
     }
     if (t != discriminator)
     {

--- a/tests/union/checks.h
+++ b/tests/union/checks.h
@@ -21,7 +21,7 @@ check_bad_param (
     switch (t)
     {
       case Test::DataType::dtEmpty: break;
-      case Test::DataType::dtLong:  d.longData (); break;
+      case Test::DataType::dtLong: d.longData (); break;
       case Test::DataType::dtShort: d.shortData (); break;
       case Test::DataType::dtString:d.stringData (); break;
       case Test::DataType::dtPoint: d.pointData (); break;

--- a/tests/union/client.cpp
+++ b/tests/union/client.cpp
@@ -374,6 +374,15 @@ test_data_z (IDL::traits<Test::Foo>::ref_type foo)
       << data << "> - <" << ret << ">." << std::endl;
   }
 
+  data.z_string() = "Bar";
+  if (data.z_string () != "Bar")
+  {
+    TAOX11_TEST_ERROR << "ERROR: Unexpected data found in Z_Union data: "
+      << "expected <\"Bar\"> - found <" << data.z_string () << ">"
+      << std::endl;
+    ++retval;
+  }
+
   // Check that passing an invalid discriminator will result in an exception
   Test::Z_Union data2;
   try

--- a/tests/union/test.idl
+++ b/tests/union/test.idl
@@ -184,6 +184,14 @@ module Test
       // by default (implicit), empty union
     };
 
+  typedef long mylong;
+  union DefaultDataTypeDef switch (short)
+    {
+      case 1: long longData;
+      case 2: short shortData;
+      default: mylong defData;
+    };
+
   union DefaultData switch (short)
     {
       case 1: long longData;


### PR DESCRIPTION
Leverage `std::variant` as type-safe union which reduces the generated code for IDL unions significantly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Accessors and discriminator getters marked nodiscard.
  * Several special member operations (constructors, assignments, destructor) defaulted for clearer semantics.

* **Refactor**
  * Union storage and initialization moved to an index-based, variant-backed approach with simplified swap and init behavior.
  * Generated headers now include variant support.

* **Tests**
  * Added a typedef and union test plus an extra runtime check validating default-member behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->