### PR TITLE
Upgrade minimum gcc version to 13, ruby to 3.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,16 +63,16 @@ jobs:
             PackageDeps: g++-13
             make_flags: '--release'
           - os: ubuntu-24.04
-            CC: gcc-13
-            CXX: g++-13
+            CC: gcc-14
+            CXX: g++-14
             ruby: '3.2'
-            PackageDeps: g++-13
+            PackageDeps: g++-14
             make_flags: '--release'
           - os: ubuntu-24.04
-            CC: gcc-13
-            CXX: g++-13
+            CC: gcc-14
+            CXX: g++-14
             ruby: '3.2'
-            PackageDeps: g++-13
+            PackageDeps: g++-14
             make_flags: '--debug'
           - os: ubuntu-24.04
             CC: gcc-13

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,50 +44,45 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
-            CC: gcc-9
-            CXX: g++-9
-            ruby: '2.5'
-            PackageDeps: g++-9
-          - os: ubuntu-22.04
-            CC: gcc-9
-            CXX: g++-9
-            ruby: '2.6'
-            PackageDeps: g++-9
-            feature: Codecov
-          - os: ubuntu-22.04
-            CC: gcc-10
-            CXX: g++-10
+          - os: ubuntu-24.04
+            CC: gcc-13
+            CXX: g++-13
             ruby: '3.0'
-            PackageDeps: g++-10
-          - os: ubuntu-22.04
-            CC: gcc-11
-            CXX: g++-11
+            PackageDeps: g++-13
+            make_flags: '--release'
+          - os: ubuntu-24.04
+            CC: gcc-13
+            CXX: g++-13
             ruby: '3.0'
-            PackageDeps: g++-11
-          - os: ubuntu-22.04
-            CC: gcc-12
-            CXX: g++-12
+            PackageDeps: g++-13
+            make_flags: '--debug'
+          - os: ubuntu-24.04
+            CC: gcc-13
+            CXX: g++-13
             ruby: '3.1'
-            PackageDeps: g++-12
-          - os: ubuntu-22.04
-            CC: gcc-12
-            CXX: g++-12
-            ruby: '3.2'
-            PackageDeps: g++-12
+            PackageDeps: g++-13
+            make_flags: '--release'
           - os: ubuntu-24.04
             CC: gcc-13
             CXX: g++-13
             ruby: '3.2'
             PackageDeps: g++-13
-          - os: ubuntu-22.04
-            CC: gcc-10
-            CXX: g++-10
-            ruby: '2.7'
-            PackageDeps: g++-10
+            make_flags: '--release'
+          - os: ubuntu-24.04
+            CC: gcc-13
+            CXX: g++-13
+            ruby: '3.2'
+            PackageDeps: g++-13
+            make_flags: '--debug'
+          - os: ubuntu-24.04
+            CC: gcc-13
+            CXX: g++-13
+            ruby: '3.0'
+            PackageDeps: g++-13
             feature: CodeQL
+            make_flags: '--release'
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} ${{ matrix.CXX }} ruby-${{ matrix.ruby }}
+    name: ${{ matrix.os }} ${{ matrix.CXX }} ruby-${{ matrix.ruby }} ${{ matrix.make_flags }}
     env:
       CC: ${{ matrix.CC }}
       CXX: ${{ matrix.CXX }}
@@ -155,7 +150,7 @@ jobs:
         $X11_BASE_ROOT/bin/brix11 gen build axcioma/workspace.mwc -- gen build $TAOX11_ROOT/examples -- gen build $TAOX11_ROOT/orbsvcs/tests -- gen build $TAOX11_ROOT/tests
     - name: Run brix11 make
       run: |
-        $X11_BASE_ROOT/bin/brix11 make -N $X11_BASE_ROOT -- make -N $TAOX11_ROOT/examples -- make -N $TAOX11_ROOT/orbsvcs/tests -- make -N $TAOX11_ROOT/tests
+        $X11_BASE_ROOT/bin/brix11 make ${{ matrix.make_flags }} -N $X11_BASE_ROOT -- make ${{ matrix.make_flags }} -N $TAOX11_ROOT/examples -- make ${{ matrix.make_flags }} -N $TAOX11_ROOT/orbsvcs/tests -- make ${{ matrix.make_flags }} -N $TAOX11_ROOT/tests
     - name: Run brix11 tests
       run: |
         $X11_BASE_ROOT/bin/brix11 run list -l $TAOX11_ROOT/bin/taox11_tests.lst -r $TAOX11_ROOT

--- a/docs/src/getting_started.adoc
+++ b/docs/src/getting_started.adoc
@@ -134,7 +134,7 @@ control your logging output and format.
 
 TAOX11 has been tested with the following compilers
 
-* GCC version 11 or newer
+* GCC version 13 or newer
 * Microsoft Visual Studio 2022
 
 === Supported platforms
@@ -168,7 +168,7 @@ Before compiling TAOX11 check the following prerequisites
 [cols="<,<",options="header",]
 |=========================================
 |Prerequisite |Package name
-|ruby 2.5 through 3.1.2 |ruby
+|ruby 3.0 through 3.1.2 |ruby
 |perl v5.10 through v5.36 |perl
 |=========================================
 
@@ -177,8 +177,8 @@ On Linux make sure you have installed the following additional prerequisites
 [cols="<,<",options="header",]
 |=========================================
 |Prerequisite |Package name
-|gcc version 11 or newer |gcc
-|g++ version 11 or newer |gcc-c++
+|gcc version 13 or newer |gcc
+|g++ version 13 or newer |gcc-c++
 |GNU make version 3.81 or newer |make
 |GNU Bash|bash
 |=========================================

--- a/tests/tie/client.cpp
+++ b/tests/tie/client.cpp
@@ -11,12 +11,6 @@
 #include "ace/Get_Opt.h"
 #include "testlib/taox11_testlog.h"
 
-// GCC 4.x and 6 have a bug which prevents us to use the tie
-// specialization without specifying the namespace explicitly
-#if defined __GNUC__ && (__GNUC__ < 7)
-#define TAOX11_LACKS_TIE_SPECIALIZATION
-#endif
-
 const ACE_TCHAR *ior = ACE_TEXT ("file://test.ior");
 
 bool
@@ -87,21 +81,12 @@ int main(int argc, char* argv[])
       TAOX11_TEST_INFO << "hello->get_string () returned <" << hello_string
         << ">" << std::endl;
 
-#if !defined (TAOX11_LACKS_TIE_SPECIALIZATION)
       if (hello_string != Test::foo)
       {
         TAOX11_TEST_ERROR << "ERROR: get_string returned <" << hello_string
                           << "> but should have returned <" << Test::foo << ">"
                           << std::endl;
       }
-#else
-      if (hello_string != Test::regular_foo)
-      {
-        TAOX11_TEST_ERROR << "ERROR: get_string returned <" << hello_string
-                          << "> but should have returned <" << Test::regular_foo << ">"
-                          << std::endl;
-      }
-#endif /* !TAOX11_LACKS_TIE_SPECIALIZATION */
 
       char const at_char_ = hello->at_char();
 

--- a/tests/tie/server.cpp
+++ b/tests/tie/server.cpp
@@ -13,20 +13,12 @@
 #include <fstream>
 #include "testS.h"
 
-// GCC 4.x and 6 have a bug which prevents us to use the tie
-// specialization without specifying the namespace explicitly
-#if defined __GNUC__ && (__GNUC__ < 7)
-#define TAOX11_LACKS_TIE_SPECIALIZATION
-#endif
-
-#if !defined (TAOX11_LACKS_TIE_SPECIALIZATION)
 template <>
 std::string
 CORBA::servant_traits<Test::Hello>::tie_type<Hello_impl>::get_string()
 {
   return _tied_object()->get_string2 ();
 }
-#endif /* !TAOX11_LACKS_TIE_SPECIALIZATION */
 
 int
 main(int argc, ACE_TCHAR *argv[])


### PR DESCRIPTION
    * .github/workflows/linux.yml:
    * docs/src/getting_started.adoc:
    * tests/tie/client.cpp:
    * tests/tie/server.cpp:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum compiler requirement to GCC 13+ (previously 11+)
  * Updated Ruby version requirements to 3.0-3.1.2
  * Added documentation describing memory management improvements using modern C++ semantics (std::shared_ptr, std::weak_ptr, move semantics)

* **Chores**
  * Updated CI workflow to target Ubuntu 24.04 with GCC 13/14 and newer Ruby versions
  * Simplified build test cases by removing conditional compilation directives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->